### PR TITLE
Allow multiple references to the same footnote

### DIFF
--- a/markdown.php
+++ b/markdown.php
@@ -2748,14 +2748,12 @@ class MarkdownExtra_Parser extends Markdown_Parser {
 	function _appendFootnotes_callback($matches) {
 		$node_id = $this->fn_id_prefix . $matches[1];
 		
-		# Create footnote marker only if it has a corresponding footnote *and*
-		# the footnote hasn't been used by another marker.
+		# Create footnote marker only if it has a corresponding footnote
 		if (isset($this->footnotes[$node_id])) {
-			# Transfert footnote content to the ordered list.
+			# Transfer footnote content to the ordered list.
 			$this->footnotes_ordered[$node_id] = $this->footnotes[$node_id];
-			unset($this->footnotes[$node_id]);
 			
-			$num = $this->footnote_counter++;
+			$num = $matches[1];
 			$attr = " rel=\"footnote\"";
 			if ($this->fn_link_class != "") {
 				$class = $this->fn_link_class;


### PR DESCRIPTION
Currently the following markdown doesn't parse as I'd expect:

```
    - refer to footnote A[^1]
    - refer to footnote B[^2]
    - refer to footnote A again[^1]

[^1]: footnote A
[^2]: footnote B
```

The "refer to footnote A again[^1]" line doesn't get linked to footnote A.

I've modified the footnote callback so that this is possible.
