### PR TITLE
Define autoload for Composer.

### DIFF
--- a/composer.json
+++ b/composer.json
@@ -20,6 +20,9 @@
 	"require": {
 		"php": ">=5.3.0"
 	},
+    "autoload": {
+        "psr-0": { "michelf": "" }
+    },
 	"extra": {
 		"branch-alias": {
 			"dev-lib": "1.3.x-dev"


### PR DESCRIPTION
As I mentioned [here](https://github.com/michelf/php-markdown/pull/42#issuecomment-9515517), the `composer.json` needs to have autoload information in order for Composer to actually be able to autoload the classes.

It would probably be good to have a new beta2 tag as soon as this goes in as anyone who asks for `@beta` or `minimum-stability: beta` is going to have a problem with the existing beta1 version.

It would probably be good to test an install from Packagist using `@dev` after this change is merged to make sure that there are not other issues _before_ doing the beta2 tag, though.

I'm happy to help! Excited to start directing people here over my fork. :)
