### PR TITLE
Support for 1.1 as ordered list, rid off PHP warnings

### DIFF
--- a/Michelf/Markdown.php
+++ b/Michelf/Markdown.php
@@ -788,7 +788,7 @@ class Markdown {
 
 		# Re-usable patterns to match list item bullets and number markers:
 		$marker_ul_re  = '[*+-]';
-		$marker_ol_re  = '\d+[\.][0-9A-Za-z\.]*';
+		$marker_ol_re  = '\d+[\.][0-9\.]*';
 		$marker_any_re = "(?:$marker_ul_re|$marker_ol_re)";
 
 		$markers_relist = array(
@@ -849,7 +849,7 @@ class Markdown {
 	protected function _doLists_callback($matches) {
 		# Re-usable patterns to match list item bullets and number markers:
 		$marker_ul_re  = '[*+-]';
-		$marker_ol_re  = '\d+[\.][0-9A-Za-z\.]*';
+		$marker_ol_re  = '\d+[\.][0-9\.]*';
 		$marker_any_re = "(?:$marker_ul_re|$marker_ol_re)";
 		
 		$list = $matches[1];

--- a/Michelf/Markdown.php
+++ b/Michelf/Markdown.php
@@ -2598,7 +2598,7 @@ class _MarkdownExtra_TmpImpl extends \Michelf\Markdown {
 		$text .= "<thead>\n";
 		$text .= "<tr>\n";
 		foreach ($headers as $n => $header) {
-			$tmp = @$attr[$n];
+			$tmp = isset($attr[$n])?$attr[$n]:'';
 			$text .= "  <th$tmp>".$this->runSpanGamut(trim($header))."</th>\n";
 		}
 		$text .= "</tr>\n";
@@ -2619,7 +2619,7 @@ class _MarkdownExtra_TmpImpl extends \Michelf\Markdown {
 			
 			$text .= "<tr>\n";
 			foreach ($row_cells as $n => $cell) {
-				$tmp = @$attr[$n];
+				$tmp = isset($attr[$n])?$attr[$n]:'';
 				$text .= "  <td$tmp>".$this->runSpanGamut(trim($cell))."</td>\n";
 			}
 			$text .= "</tr>\n";

--- a/Michelf/Markdown.php
+++ b/Michelf/Markdown.php
@@ -788,7 +788,7 @@ class Markdown {
 
 		# Re-usable patterns to match list item bullets and number markers:
 		$marker_ul_re  = '[*+-]';
-		$marker_ol_re  = '\d+[\.]';
+		$marker_ol_re  = '\d+[0-9\.]+';
 		$marker_any_re = "(?:$marker_ul_re|$marker_ol_re)";
 
 		$markers_relist = array(
@@ -849,7 +849,7 @@ class Markdown {
 	protected function _doLists_callback($matches) {
 		# Re-usable patterns to match list item bullets and number markers:
 		$marker_ul_re  = '[*+-]';
-		$marker_ol_re  = '\d+[\.]';
+		$marker_ol_re  = '\d+[0-9\.]+';
 		$marker_any_re = "(?:$marker_ul_re|$marker_ol_re)";
 		
 		$list = $matches[1];
@@ -2597,8 +2597,10 @@ class _MarkdownExtra_TmpImpl extends \Michelf\Markdown {
 		$text = "<table>\n";
 		$text .= "<thead>\n";
 		$text .= "<tr>\n";
-		foreach ($headers as $n => $header)
-			$text .= "  <th$attr[$n]>".$this->runSpanGamut(trim($header))."</th>\n";
+		foreach ($headers as $n => $header) {
+			$tmp = @$attr[$n];
+			$text .= "  <th$tmp>".$this->runSpanGamut(trim($header))."</th>\n";
+		}
 		$text .= "</tr>\n";
 		$text .= "</thead>\n";
 		
@@ -2616,8 +2618,10 @@ class _MarkdownExtra_TmpImpl extends \Michelf\Markdown {
 			$row_cells = array_pad($row_cells, $col_count, '');
 			
 			$text .= "<tr>\n";
-			foreach ($row_cells as $n => $cell)
-				$text .= "  <td$attr[$n]>".$this->runSpanGamut(trim($cell))."</td>\n";
+			foreach ($row_cells as $n => $cell) {
+				$tmp = @$attr[$n];
+				$text .= "  <td$tmp>".$this->runSpanGamut(trim($cell))."</td>\n";
+			}
 			$text .= "</tr>\n";
 		}
 		$text .= "</tbody>\n";

--- a/Michelf/Markdown.php
+++ b/Michelf/Markdown.php
@@ -788,7 +788,7 @@ class Markdown {
 
 		# Re-usable patterns to match list item bullets and number markers:
 		$marker_ul_re  = '[*+-]';
-		$marker_ol_re  = '\d+[0-9\.]+';
+		$marker_ol_re  = '\d+[\.][0-9A-Za-z\.]*';
 		$marker_any_re = "(?:$marker_ul_re|$marker_ol_re)";
 
 		$markers_relist = array(
@@ -849,7 +849,7 @@ class Markdown {
 	protected function _doLists_callback($matches) {
 		# Re-usable patterns to match list item bullets and number markers:
 		$marker_ul_re  = '[*+-]';
-		$marker_ol_re  = '\d+[0-9\.]+';
+		$marker_ol_re  = '\d+[\.][0-9A-Za-z\.]*';
 		$marker_any_re = "(?:$marker_ul_re|$marker_ol_re)";
 		
 		$list = $matches[1];


### PR DESCRIPTION
Support for 1.1 as ordered list:

![image](https://f.cloud.github.com/assets/1345694/425824/1facdb30-adb9-11e2-8513-21a50a12e5eb.png)

and some PHP warnings
