### PR TITLE
add auto transfer inner link mode

### DIFF
--- a/Michelf/Markdown.php
+++ b/Michelf/Markdown.php
@@ -59,6 +59,9 @@ class Markdown {
 	public $predef_urls = array();
 	public $predef_titles = array();
 
+	# auto transfer implicit link [text] to inner link
+	public $auto_inner_link = false;
+
 
 	### Parser Implementation ###
 
@@ -578,6 +581,7 @@ class Markdown {
 		return $text;
 	}
 	protected function _doAnchors_reference_callback($matches) {
+		$is_implicit = !isset($matches[3]);
 		$whole_match =  $matches[1];
 		$link_text   =  $matches[2];
 		$link_id     =& $matches[3];
@@ -601,6 +605,17 @@ class Markdown {
 				$title = $this->encodeAttribute($title);
 				$result .=  " title=\"$title\"";
 			}
+		
+			$link_text = $this->runSpanGamut($link_text);
+			$result .= ">$link_text</a>";
+			$result = $this->hashPart($result);
+		}
+		elseif ($is_implicit && $this->auto_inner_link) {
+			$url = $this->encodeAttribute($link_id);
+			
+			$result = "<a href=\"$url\"";
+			$title = $this->encodeAttribute($link_id);
+			$result .=  " title=\"$title\"";
 		
 			$link_text = $this->runSpanGamut($link_text);
 			$result .= ">$link_text</a>";


### PR DESCRIPTION
if this option is set to true, the implicit link [text] not after by
[id] or () will be transform to [text](text)
