### PR TITLE
Convert public member comments to PHPDoc format

### DIFF
--- a/Michelf/MarkdownExtra.php
+++ b/Michelf/MarkdownExtra.php
@@ -1,15 +1,14 @@
 <?php
-#
-# Markdown Extra  -  A text-to-HTML conversion tool for web writers
-#
-# PHP Markdown Extra
-# Copyright (c) 2004-2013 Michel Fortin  
-# <http://michelf.com/projects/php-markdown/>
-#
-# Original Markdown
-# Copyright (c) 2004-2006 John Gruber  
-# <http://daringfireball.net/projects/markdown/>
-#
+
+/**
+ * Markdown Extra - A text-to-HTML conversion tool for web writers
+ *
+ * @copyright 2004-2013 Michel Fortin <http://michelf.com/projects/php-markdown/>
+ * @copyright (Original Markdown) 2004-2006 John Gruber <http://daringfireball.net/projects/markdown/>
+ *
+ * @license http://michelf.ca/projects/php-markdown/#license
+ */
+
 namespace Michelf;
 
 
@@ -17,22 +16,18 @@ namespace Michelf;
 # the temporary implementation class. See below for details.
 \Michelf\Markdown::MARKDOWNLIB_VERSION;
 
-#
-# Markdown Extra Parser Class
-#
-# Note: Currently the implementation resides in the temporary class
-# \Michelf\MarkdownExtra_TmpImpl (in the same file as \Michelf\Markdown).
-# This makes it easier to propagate the changes between the three different
-# packaging styles of PHP Markdown. Once this issue is resolved, the
-# _MarkdownExtra_TmpImpl will disappear and this one will contain the code.
-#
-
+/**
+ * Markdown Extra Parser Class
+ *
+ * Note: Currently the implementation resides in the temporary class
+ * \Michelf\MarkdownExtra_TmpImpl (in the same file as \Michelf\Markdown).
+ * This makes it easier to propagate the changes between the three different
+ * packaging styles of PHP Markdown. Once this issue is resolved, the
+ * _MarkdownExtra_TmpImpl will disappear and this one will contain the code.
+ *
+ * @see Michelf\_MarkdownExtra_TmpImpl
+ */
 class MarkdownExtra extends \Michelf\_MarkdownExtra_TmpImpl {
-
-	### Parser Implementation ###
-
-	# Temporarily, the implemenation is in the _MarkdownExtra_TmpImpl class.
-	# See note above.
 
 }
 


### PR DESCRIPTION
This is the promised pull request discussed in #98. This may be largely academic and not worth merging, however. It turns out there is [a PSR draft proposal](https://github.com/phpDocumentor/phpDocumentor2/blob/develop/docs/PSR.md) being worked out by the phpDocumentor team which may be worth adopting instead whenever it becomes a full PSR.

It's been in development for a couple of years now with no ETA on even a proposal, but it is intended to obsolete the PHPDoc "de-facto" standard, there's been some movement on the FIG side to get a documentation standard going, and it seems likely that the FIG will eventually adopt a documentation standard within the coming months.

So, given the timeline of removing legacy bits of Markdown that would prevent a wholesale conversion of all the comments, it may be worth postponing this entirely to see what the FIG  does in the meantime.

All that said, I still created the PR for informational purposes and a jumping off point for discussions about how best to convert the comments whether it's done now or after a PSR emerges.

As suggested, only comments on public members were converted. I interpreted that as follows:
- The file-level comments were converted over. I couldn't find any guidance on how to handle multiple, disparate copyright tags, so the use of parens to denote John Gruber's copyright claim is definitely malleable.
- The class-level comments for `Markdown`, `MarkdownExtra`, and `_MarkdownExtra_TmpImpl` were converted over. The first two are uncontroversial. I converted `_MarkdownExtra_Tmplmpl` because, while an internal class, it contained public members. I marked it with the `@internal` tag to help avoid ambiguity by people relying on IDEs and such to determine what's usable.
- The `MARKDOWNLIB_VERSION` constant was converted over.
- The constructor comments were converted over under the premise that they are technically public method, even if their usage is either unnecessary or self-documenting due to lack of parameters.
- I made the call to convert the comments within public methods over as well. My reasoning for this was to avoid mixing commenting styles within a single logical block, but I'm not wedded to it.
- Where I saw an opportunity, I removed phrases or sentences that duplicated a tag. An example is changing _Change to `true` to disallow markup or entities_ to simply _Disallow markup_ because the `@var boolean` tag indicates the allowed values. 

As an aside, in writing this, it was—for lack of a better word—weird to have two styles of commenting mixed together in the same file. Barring the PSR issue, that alone may be worth postponing this issue until everything can be converted over.
