### PR TITLE
Excluded trailing ?>'s on class code per PSR-2 Subheading 2.2

### DIFF
--- a/Michelf/Markdown.php
+++ b/Michelf/Markdown.php
@@ -3092,5 +3092,3 @@ class _MarkdownExtra_TmpImpl extends \Michelf\Markdown {
 
 }
 
-
-?>

--- a/Michelf/MarkdownExtra.php
+++ b/Michelf/MarkdownExtra.php
@@ -36,5 +36,3 @@ class MarkdownExtra extends \Michelf\_MarkdownExtra_TmpImpl {
 
 }
 
-
-?>


### PR DESCRIPTION
Its generally good practice to exclude closing tags on PHP only files to prevent trailing white space causing unexpected output, and PSR-2 (declares)[https://github.com/php-fig/fig-standards/blob/master/accepted/PSR-2-coding-style-guide.md#22-files]:

"The closing ?> tag MUST be omitted from files containing only PHP"
