### PR TITLE
Header offset setting

### DIFF
--- a/Michelf/Markdown.php
+++ b/Michelf/Markdown.php
@@ -2475,13 +2475,13 @@ class _MarkdownExtra_TmpImpl extends \Michelf\Markdown {
 	protected function _doHeaders_callback_setext($matches) {
 		if ($matches[3] == '-' && preg_match('{^- }', $matches[1]))
 			return $matches[0];
-		$level = $matches[3]{0} == '=' ? 1 : 2;
+		$level = $matches[3]{0} == '=' ? 1 : 2 + $this->header_offset;
 		$attr  = $this->doExtraAttributes("h$level", $dummy =& $matches[2]);
 		$block = "<h$level$attr>".$this->runSpanGamut($matches[1])."</h$level>";
 		return "\n" . $this->hashBlock($block) . "\n\n";
 	}
 	protected function _doHeaders_callback_atx($matches) {
-		$level = strlen($matches[1]);
+		$level = strlen($matches[1]) + $this->header_offset;
 		$attr  = $this->doExtraAttributes("h$level", $dummy =& $matches[3]);
 		$block = "<h$level$attr>".$this->runSpanGamut($matches[2])."</h$level>";
 		return "\n" . $this->hashBlock($block) . "\n\n";

--- a/Michelf/Markdown.php
+++ b/Michelf/Markdown.php
@@ -58,6 +58,10 @@ class Markdown {
 	# Predefined urls and titles for reference links and images.
 	public $predef_urls = array();
 	public $predef_titles = array();
+	
+	# Offset for header levels, i.e., if you want the first heading to be H2,
+	# make the offset 1
+	public $header_offset = 0;
 
 
 	### Parser Implementation ###
@@ -769,12 +773,12 @@ class Markdown {
 		if ($matches[2] == '-' && preg_match('{^-(?: |$)}', $matches[1]))
 			return $matches[0];
 		
-		$level = $matches[2]{0} == '=' ? 1 : 2;
+		$level = $matches[2]{0} == '=' ? 1 : 2 + $this->header_offset;
 		$block = "<h$level>".$this->runSpanGamut($matches[1])."</h$level>";
 		return "\n" . $this->hashBlock($block) . "\n\n";
 	}
 	protected function _doHeaders_callback_atx($matches) {
-		$level = strlen($matches[1]);
+		$level = strlen($matches[1]) + $this->header_offset;
 		$block = "<h$level>".$this->runSpanGamut($matches[2])."</h$level>";
 		return "\n" . $this->hashBlock($block) . "\n\n";
 	}


### PR DESCRIPTION
I'm writing a page which displays articles and consists of a page title as H1, and then the article content translated from markdown.  I'd like to be able to start the header numbering of the content at H2, so I've made this fork.  This is related to https://github.com/michelf/php-markdown/pull/102, but I prefer my implementation.  There is an open issue for this feature here: https://github.com/michelf/php-markdown/issues/117
