### PR TITLE
Add support for backtick fenced code blocks

### DIFF
--- a/Michelf/Markdown.php
+++ b/Michelf/Markdown.php
@@ -2761,6 +2761,11 @@ class _MarkdownExtra_TmpImpl extends \Michelf\Markdown {
 	# Code block
 	# ~~~
 	#
+	# OR
+	#
+	# ```
+	# Code block
+	# ```
 		$less_than_tab = $this->tab_width;
 		
 		$text = preg_replace_callback('{
@@ -2768,6 +2773,8 @@ class _MarkdownExtra_TmpImpl extends \Michelf\Markdown {
 				# 1: Opening marker
 				(
 					~{3,} # Marker: three tilde or more.
+					|
+					`{3,} # Or marker: three backticks or more (GFM)
 				)
 				[ ]*
 				(?:


### PR DESCRIPTION
Based off the work by @rbewley4 in #84, this small change adds support for backtick fenced code blocks, a la Github Flavored Markdown.

This is a grouped PR, and also includes new test cases in the mdtest fork: ciarand/mdtest@d722fdca32dc28909f4b4beafe5a22dd992aba60
