### PR TITLE
GFM Enhancements (Backticks)

### DIFF
--- a/Michelf/Markdown.php
+++ b/Michelf/Markdown.php
@@ -1847,7 +1847,6 @@ class _MarkdownExtra_TmpImpl extends \Michelf\Markdown {
 					# Fenced code block marker
 					(?<= ^ | \n )
 					[ ]{0,'.($indent+3).'}(?:~{3,}|`{3,})
-					[A-Za-z0-9_\-]* # Language (optional).
 									[ ]*
 					(?:
 					\.?[-_:a-zA-Z0-9]+ # standalone class name
@@ -2762,10 +2761,6 @@ class _MarkdownExtra_TmpImpl extends \Michelf\Markdown {
 	# Code block
 	# ~~~
 	#
-	# ```
-	# Code block
-	# ```
-	#
 		$less_than_tab = $this->tab_width;
 		
 		$text = preg_replace_callback('{
@@ -2774,19 +2769,15 @@ class _MarkdownExtra_TmpImpl extends \Michelf\Markdown {
 				(
 					(?:~{3,}|`{3,}) # 3 or more tildes/backticks.
 				)
-				# 2: Code language marker (optional).
-				(
-					[A-Za-z0-9_\-]* # Word chars and/or `-`.
-				)
 				[ ]*
 				(?:
-					\.?([-_:a-zA-Z0-9]+) # 3: Stand-alone class name.
+					\.?([-_:a-zA-Z0-9]+) # 2: standalone class name
 				|
-					'.$this->id_class_attr_catch_re.' # 4: Extra attributes.
+					'.$this->id_class_attr_catch_re.' # 3: Extra attributes
 				)?
 				[ ]* \n # Whitespace and newline following marker.
 				
-				# 5: Content
+				# 4: Content
 				(
 					(?>
 						(?!\1 [ ]* \n)	# Not a closing marker.
@@ -2802,23 +2793,19 @@ class _MarkdownExtra_TmpImpl extends \Michelf\Markdown {
 		return $text;
 	}
 	protected function _doFencedCodeBlocks_callback($matches) {
-		$language  = $matches[2];
-		$classname = $matches[3];
-		$attrs     = $matches[4];
-		$codeblock = $matches[5];
+		$classname =& $matches[2];
+		$attrs     =& $matches[3];
+		$codeblock = $matches[4];
 		$codeblock = htmlspecialchars($codeblock, ENT_NOQUOTES);
 		$codeblock = preg_replace_callback('/^\n+/',
 			array(&$this, '_doFencedCodeBlocks_newlines'), $codeblock);
-		
-		$attr_str = ''; # Initialize string of attributes.
-		if($language != '') $attr_str .= ' data-lang="'.$language.'"';
 
 		if ($classname != "") {
 			if ($classname{0} == '.')
 				$classname = substr($classname, 1);
-			$attr_str .= ' class="'.$this->code_class_prefix.$classname.'"';
+			$attr_str = ' class="'.$this->code_class_prefix.$classname.'"';
 		} else {
-			$attr_str .= $this->doExtraAttributes($this->code_attr_on_pre ? "pre" : "code", $attrs);
+			$attr_str = $this->doExtraAttributes($this->code_attr_on_pre ? "pre" : "code", $attrs);
 		}
 		$pre_attr_str  = $this->code_attr_on_pre ? $attr_str : '';
 		$code_attr_str = $this->code_attr_on_pre ? '' : $attr_str;

--- a/Michelf/Markdown.php
+++ b/Michelf/Markdown.php
@@ -1846,7 +1846,7 @@ class _MarkdownExtra_TmpImpl extends \Michelf\Markdown {
 				|
 					# Fenced code block marker
 					(?<= ^ | \n )
-					[ ]{0,'.($indent+3).'}[`~]{3,}
+					[ ]{0,'.($indent+3).'}(?:~{3,}|`{3,})
 					[A-Za-z0-9_\-]* # Language (optional).
 									[ ]*
 					(?:
@@ -1919,7 +1919,7 @@ class _MarkdownExtra_TmpImpl extends \Michelf\Markdown {
 			#
 			# Check for: Fenced code block marker.
 			#
-			else if (preg_match('{^\n?([ ]{0,'.($indent+3).'})([`~]+)}', $tag, $capture)) {
+			else if (preg_match('{^\n?([ ]{0,'.($indent+3).'})(~+|`+)}', $tag, $capture)) {
 				# Fenced code block marker: find matching end marker.
 				$fence_indent = strlen($capture[1]); # use captured indent in re
 				$fence_re = $capture[2]; # use captured fence in re
@@ -2772,7 +2772,7 @@ class _MarkdownExtra_TmpImpl extends \Michelf\Markdown {
 				(?:\n|\A)
 				# 1: Opening marker
 				(
-					[`~]{3,} # 3 or more backticks/tildes.
+					(?:~{3,}|`{3,}) # 3 or more tildes/backticks.
 				)
 				# 2: Code language marker (optional).
 				(
@@ -2811,7 +2811,7 @@ class _MarkdownExtra_TmpImpl extends \Michelf\Markdown {
 			array(&$this, '_doFencedCodeBlocks_newlines'), $codeblock);
 		
 		$attr_str = ''; # Initialize string of attributes.
-		if($language != '') $attr_str .= ' lang="'.$language.'"';
+		if($language != '') $attr_str .= ' data-lang="'.$language.'"';
 
 		if ($classname != "") {
 			if ($classname{0} == '.')


### PR DESCRIPTION
- Adding support for GFM backticks (for fenced code blocks); in additional to ~~~ already supported in Markdown Extra.
- Adding support for GFM language marker with fenced code blocks.
