### PR TITLE
Add $this->default_code_class configuration option for fenced code blocks

### DIFF
--- a/Michelf/Markdown.php
+++ b/Michelf/Markdown.php
@@ -1553,6 +1553,10 @@ abstract class _MarkdownExtra_TmpImpl extends \Michelf\Markdown {
 
 	# Optional class prefix for fenced code block.
 	public $code_class_prefix = "";
+
+	# Optional default class(es) for fenced code block.
+	public $default_code_class = "";
+
 	# Class attribute for code blocks goes on the `code` tag;
 	# setting this to true will put attributes on the `pre` tag instead.
 	public $code_attr_on_pre = false;
@@ -1663,7 +1667,7 @@ abstract class _MarkdownExtra_TmpImpl extends \Michelf\Markdown {
 		$elements = $matches[0];
 
 		# handle classes and ids (only first id taken into account)
-		$classes = array();
+		$classes = array($this->default_code_class);
 		$id = false;
 		foreach ($elements as $element) {
 			if ($element{0} == '.') {


### PR DESCRIPTION
Would love to be able to set a default class on all my fenced code blocks. Most, if not all, syntax highlighters require a class or two, so this would reduce repetitive markup or a brittle javascript dependency.
