### PR TITLE
Allow strong filtering of linked URLs

### DIFF
--- a/Michelf/Markdown.php
+++ b/Michelf/Markdown.php
@@ -703,7 +703,8 @@ class Markdown implements MarkdownInterface {
 
 		$alt_text = $this->encodeAttribute($alt_text);
 		if (isset($this->urls[$link_id])) {
-			$url = $this->encodeAttribute($this->urls[$link_id]);
+			$url = $this->filterUrl($this->urls[$link_id]);
+			$url = $this->encodeAttribute($url);
 			$result = "<img src=\"$url\" alt=\"$alt_text\"";
 			if (isset($this->titles[$link_id])) {
 				$title = $this->titles[$link_id];
@@ -727,6 +728,7 @@ class Markdown implements MarkdownInterface {
 		$title			=& $matches[7];
 
 		$alt_text = $this->encodeAttribute($alt_text);
+		$url = $this->filterUrl($url);
 		$url = $this->encodeAttribute($url);
 		$result = "<img src=\"$url\" alt=\"$alt_text\"";
 		if (isset($title)) {
@@ -2498,7 +2500,8 @@ abstract class _MarkdownExtra_TmpImpl extends \Michelf\Markdown {
 
 		$alt_text = $this->encodeAttribute($alt_text);
 		if (isset($this->urls[$link_id])) {
-			$url = $this->encodeAttribute($this->urls[$link_id]);
+			$url = $this->filterUrl($this->urls[$link_id]);
+			$url = $this->encodeAttribute($url);
 			$result = "<img src=\"$url\" alt=\"$alt_text\"";
 			if (isset($this->titles[$link_id])) {
 				$title = $this->titles[$link_id];
@@ -2525,6 +2528,7 @@ abstract class _MarkdownExtra_TmpImpl extends \Michelf\Markdown {
 		$attr  = $this->doExtraAttributes("img", $dummy =& $matches[8]);
 
 		$alt_text = $this->encodeAttribute($alt_text);
+		$url = $this->filterUrl($url);
 		$url = $this->encodeAttribute($url);
 		$result = "<img src=\"$url\" alt=\"$alt_text\"";
 		if (isset($title)) {

--- a/Michelf/Markdown.php
+++ b/Michelf/Markdown.php
@@ -593,6 +593,7 @@ class Markdown implements MarkdownInterface {
 
 		if (isset($this->urls[$link_id])) {
 			$url = $this->urls[$link_id];
+			$url = $this->filterUrl($url);
 			$url = $this->encodeAttribute($url);
 			
 			$result = "<a href=\"$url\"";
@@ -617,6 +618,7 @@ class Markdown implements MarkdownInterface {
 		$url			=  $matches[3] == '' ? $matches[4] : $matches[3];
 		$title			=& $matches[7];
 
+		$url = $this->filterUrl($url);
 		$url = $this->encodeAttribute($url);
 
 		$result = "<a href=\"$url\"";
@@ -1307,13 +1309,15 @@ class Markdown implements MarkdownInterface {
 		return $text;
 	}
 	protected function _doAutoLinks_tel_callback($matches) {
-		$url = $this->encodeAttribute($matches[1]);
+		$url = $this->filterUrl($matches[1]);
+		$url = $this->encodeAttribute($url);
 		$tel = $this->encodeAttribute($matches[2]);
 		$link = "<a href=\"$url\">$tel</a>";
 		return $this->hashPart($link);
 	}
 	protected function _doAutoLinks_url_callback($matches) {
-		$url = $this->encodeAttribute($matches[1]);
+		$url = $this->filterUrl($matches[1]);
+		$url = $this->encodeAttribute($url);
 		$link = "<a href=\"$url\">$url</a>";
 		return $this->hashPart($link);
 	}
@@ -1516,6 +1520,11 @@ class Markdown implements MarkdownInterface {
 		return $this->html_hashes[$matches[0]];
 	}
 
+
+	protected function filterUrl($url){
+
+		return $url;
+	}
 }
 
 
@@ -2290,6 +2299,7 @@ abstract class _MarkdownExtra_TmpImpl extends \Michelf\Markdown {
 
 		if (isset($this->urls[$link_id])) {
 			$url = $this->urls[$link_id];
+			$url = $this->filterUrl($url);
 			$url = $this->encodeAttribute($url);
 			
 			$result = "<a href=\"$url\"";
@@ -2317,7 +2327,7 @@ abstract class _MarkdownExtra_TmpImpl extends \Michelf\Markdown {
 		$title			=& $matches[7];
 		$attr  = $this->doExtraAttributes("a", $dummy =& $matches[8]);
 
-
+		$url = $this->filterUrl($url);
 		$url = $this->encodeAttribute($url);
 
 		$result = "<a href=\"$url\"";


### PR DESCRIPTION
Currently, apps using this library for turning user-entered Markdown into HTML are vulnerable to XSS attacks via allowing javascript (and others) as the protocol for links. For example:

```
[CLICK ME](javascript:alert(document.cookie))
```

This PR passes all link URLs through the `filterUrl()` method. By default, this function will allow through URls using a whitelist of protocols, or local/relative URLs without a protocol. There is some heavy decoding involved to make sure URLs like `javascript%3Aalert(document.cookie)` don't slip through.

This change breaks two tests in the current suite ("Links, inline style" & "Quotes in attributes") since they both involve putting broken URLs inside links. Changing the test to have URLs prefixed with `http://` makes these test pass correctly.
