### PR TITLE
Filter potential XSS attack in links

### DIFF
--- a/Michelf/Markdown.php
+++ b/Michelf/Markdown.php
@@ -618,6 +618,10 @@ class Markdown implements MarkdownInterface {
 		$title			=& $matches[7];
 
 		$url = $this->encodeAttribute($url);
+		
+		if(!preg_match('#^\s*(https?|ftp)://#i', $url))
+			$url = '';
+			
 
 		$result = "<a href=\"$url\"";
 		if (isset($title)) {


### PR DESCRIPTION
It Removes potential XSS attack in links, now only http:// https:// and ftp:// links are allowed. Filter is case insensitive.

```
[XSS Vulnerability](javascript:alert('xss'))
```
