### PR TITLE
Updates README. Adds Composer Install Instructions

### DIFF
--- a/Readme.md
+++ b/Readme.md
@@ -53,12 +53,12 @@ Using [Composer](https://getcomposer.org/) (the preferred method) simply run
 composer require michelf/php-markdown
 ```
 
-and the package will be installed into your `./vendor` directory.
+and the package will be installed into your `./vendor` directory and available for use. *Make sure to `require` Composer's `vendor/autoload.php` to enable autoloading throughout your project.*
 
 Usage
 -----
 
-This library package is meant to be used with class autoloading. *This is taken care of automatically if you installed via Composer.* For autoloading 
+This library package is meant to be used with class autoloading. For autoloading 
 to work, your project needs have setup a PSR-0-compatible autoloader. See the 
 included Readme.php file for a minimal autoloader setup. (If you cannot use 
 autoloading, see below.)

--- a/Readme.md
+++ b/Readme.md
@@ -43,11 +43,22 @@ Before PHP 5.3.7, pcre.backtrack_limit defaults to 100 000, which is too small
 in many situations. You might need to set it to higher values. Later PHP 
 releases defaults to 1 000 000, which is usually fine.
 
+Installation
+------------
+
+Using [Composer](https://getcomposer.org/) (the preferred method) simply run
+
+```
+# This will ensure you get the latest stable version
+composer require michelf/php-markdown
+```
+
+and the package will be installed into your `./vendor` directory.
 
 Usage
 -----
 
-This library package is meant to be used with class autoloading. For autoloading 
+This library package is meant to be used with class autoloading. *This is taken care of automatically if you installed via Composer.* For autoloading 
 to work, your project needs have setup a PSR-0-compatible autoloader. See the 
 included Readme.php file for a minimal autoloader setup. (If you cannot use 
 autoloading, see below.)

--- a/Readme.md
+++ b/Readme.md
@@ -48,10 +48,8 @@ Installation
 
 Using [Composer](https://getcomposer.org/) (the preferred method) simply run
 
-```
-# This will ensure you get the latest stable version
-composer require michelf/php-markdown
-```
+    # This will ensure you get the latest stable version
+    composer require michelf/php-markdown
 
 and the package will be installed into your `./vendor` directory and available for use. *Make sure to `require` Composer's `vendor/autoload.php` to enable autoloading throughout your project.*
 


### PR DESCRIPTION
This package is on Packagist (https://packagist.org/packages/michelf/php-markdown). 
This package promotes PSR autoloading. 
~~Hence, this package should be installed via Composer and promote the autoloading capabilities provided by Composer.~~
This makes utilizing Composer and its autoloading directive a pleasure as a user/developer.
- http://www.phptherightway.com/#dependency_management
- http://blog.doh.ms/2014/10/13/installing-composer-packages/
