### PR TITLE
Automatically generating id="" attributes

### DIFF
--- a/Michelf/Markdown.php
+++ b/Michelf/Markdown.php
@@ -812,7 +812,7 @@ class Markdown implements MarkdownInterface {
 		$idValue = call_user_func($this->header_id_func, $headerValue);
 		if (!$idValue) return "";
 
-		return 'id="' . $this->encodeAttribute($idValue) . '"';
+		return ' id="' . $this->encodeAttribute($idValue) . '"';
 
 	}
 

--- a/Michelf/Markdown.php
+++ b/Michelf/Markdown.php
@@ -785,7 +785,7 @@ class Markdown implements MarkdownInterface {
 
 		# id attribute generation
 		$idAtt = is_callable($this->header_id_func) ? call_user_func($this->header_id_func, $matches[1]) : null;
-		if ($idAtt) $idAtt = ' id="' . htmlspecialchars($idAtt, ENT_QUOTES, 'UTF-8') . '"';
+		if ($idAtt) $idAtt = ' id="' . htmlspecialchars($idAtt, ENT_COMPAT, 'UTF-8') . '"';
 
 		$block = "<h$level$idAtt>".$this->runSpanGamut($matches[2])."</h$level>";
 		return "\n" . $this->hashBlock($block) . "\n\n";
@@ -794,7 +794,7 @@ class Markdown implements MarkdownInterface {
 
         # id attribute generation
         $idAtt = is_callable($this->header_id_func) ? call_user_func($this->header_id_func, $matches[2]) : null;
-        if ($idAtt) $idAtt = ' id="' . htmlspecialchars($idAtt, ENT_QUOTES, 'UTF-8') . '"';
+        if ($idAtt) $idAtt = ' id="' . htmlspecialchars($idAtt, ENT_COMPAT, 'UTF-8') . '"';
 
 		$level = strlen($matches[1]);
 		$block = "<h$level$idAtt>".$this->runSpanGamut($matches[2])."</h$level>";
@@ -1731,10 +1731,10 @@ abstract class _MarkdownExtra_TmpImpl extends \Michelf\Markdown {
 		# compose attributes as string
 		$attr_str = "";
 		if (!empty($id)) {
-			$attr_str .= ' id="'.$id.'"';
+			$attr_str .= ' id="'.htmlspecialchars($id, ENT_COMPAT, 'UTF-8') .'"';
 		}
 		if (!empty($classes)) {
-			$attr_str .= ' class="'.implode(" ", $classes).'"';
+			$attr_str .= ' class="'.htmlspecialchars(implode(" ", $classes), ENT_COMPAT, 'UTF-8').'"';
 		}
 		if (!$this->no_markup && !empty($attributes)) {
 			$attr_str .= ' '.implode(" ", $attributes);

--- a/Michelf/Markdown.php
+++ b/Michelf/Markdown.php
@@ -790,11 +790,11 @@ class Markdown implements MarkdownInterface {
 		$block = "<h$level$idAtt>".$this->runSpanGamut($matches[2])."</h$level>";
 		return "\n" . $this->hashBlock($block) . "\n\n";
 	}
-    protected function _doHeaders_callback_atx($matches) {
+	protected function _doHeaders_callback_atx($matches) {
 
-        # id attribute generation
-        $idAtt = is_callable($this->header_id_func) ? call_user_func($this->header_id_func, $matches[2]) : null;
-        if ($idAtt) $idAtt = ' id="' . htmlspecialchars($idAtt, ENT_COMPAT, 'UTF-8') . '"';
+		# id attribute generation
+		$idAtt = is_callable($this->header_id_func) ? call_user_func($this->header_id_func, $matches[2]) : null;
+		if ($idAtt) $idAtt = ' id="' . htmlspecialchars($idAtt, ENT_COMPAT, 'UTF-8') . '"';
 
 		$level = strlen($matches[1]);
 		$block = "<h$level$idAtt>".$this->runSpanGamut($matches[2])."</h$level>";

--- a/Michelf/Markdown.php
+++ b/Michelf/Markdown.php
@@ -784,8 +784,7 @@ class Markdown implements MarkdownInterface {
 		$level = $matches[2]{0} == '=' ? 1 : 2;
 
 		# id attribute generation
-		$idAtt = is_callable($this->header_id_func) ? call_user_func($this->header_id_func, $matches[1]) : null;
-		if ($idAtt) $idAtt = ' id="' . htmlspecialchars($idAtt, ENT_COMPAT, 'UTF-8') . '"';
+		$idAtt = $this->_generateIdFromHeaderValue($matches[1]);
 
 		$block = "<h$level$idAtt>".$this->runSpanGamut($matches[2])."</h$level>";
 		return "\n" . $this->hashBlock($block) . "\n\n";
@@ -793,14 +792,29 @@ class Markdown implements MarkdownInterface {
 	protected function _doHeaders_callback_atx($matches) {
 
 		# id attribute generation
-		$idAtt = is_callable($this->header_id_func) ? call_user_func($this->header_id_func, $matches[2]) : null;
-		if ($idAtt) $idAtt = ' id="' . htmlspecialchars($idAtt, ENT_COMPAT, 'UTF-8') . '"';
+		$idAtt = $this->_generateIdFromHeaderValue($matches[2]);
 
 		$level = strlen($matches[1]);
 		$block = "<h$level$idAtt>".$this->runSpanGamut($matches[2])."</h$level>";
 		return "\n" . $this->hashBlock($block) . "\n\n";
 	}
 
+	protected function _generateIdFromHeaderValue($headerValue) {
+
+		# if a header_id_func property is set, we can use it to automatically
+		# generate an id attribute.
+		#
+		# This method returns a string in the form id="foo", or an empty string
+		# otherwise.
+		if (!is_callable($this->header_id_func)) {
+			return "";
+		}
+		$idValue = call_user_func($this->header_id_func, $headerValue);
+		if (!$idValue) return "";
+
+		return 'id="' . $this->encodeAttribute($idValue) . '"';
+
+	}
 
 	protected function doLists($text) {
 	#
@@ -1731,10 +1745,10 @@ abstract class _MarkdownExtra_TmpImpl extends \Michelf\Markdown {
 		# compose attributes as string
 		$attr_str = "";
 		if (!empty($id)) {
-			$attr_str .= ' id="'.htmlspecialchars($id, ENT_COMPAT, 'UTF-8') .'"';
+			$attr_str .= ' id="'.$this->encodeAttribute($id) .'"';
 		}
 		if (!empty($classes)) {
-			$attr_str .= ' class="'.htmlspecialchars(implode(" ", $classes), ENT_COMPAT, 'UTF-8').'"';
+			$attr_str .= ' class="'. implode(" ", $classes) . '"';
 		}
 		if (!$this->no_markup && !empty($attributes)) {
 			$attr_str .= ' '.implode(" ", $attributes);

--- a/Michelf/Markdown.php
+++ b/Michelf/Markdown.php
@@ -786,7 +786,7 @@ class Markdown implements MarkdownInterface {
 		# id attribute generation
 		$idAtt = $this->_generateIdFromHeaderValue($matches[1]);
 
-		$block = "<h$level$idAtt>".$this->runSpanGamut($matches[2])."</h$level>";
+		$block = "<h$level$idAtt>".$this->runSpanGamut($matches[1])."</h$level>";
 		return "\n" . $this->hashBlock($block) . "\n\n";
 	}
 	protected function _doHeaders_callback_atx($matches) {


### PR DESCRIPTION
Hi @michelf !

This patch does the following:
1. Adds a new public property to the markdown parses: $header_id_func.
2. If this is set, it will be called to automatically generate an id="" attribute, but only for headers that have none!
3. It also adds html escaping for both id and class attributes

Usage:

``` php
$md = new Markdown();
$md->header_id_func = function($headerName) {
    return rawurlencode(strtolower(
        strtr($headerName, [' ' => '-'])
    ));
};
$html = $md->transform($text);
```

So.. you asked only for support in `MarkdownExtra`. Before I knew it I had written a full implementation in `Markdown`. Since this doesn't break anything in `Markdown`, I thought I would keep it in for now.

But if you really only want this feature in `MarkdownExtra`, I am also happy to remove it from `Markdown` for you.

Let me know!

cc: @simensen 
