### PR TITLE
Optional code block content function added in MarkdownExtra.

### DIFF
--- a/Michelf/MarkdownExtra.php
+++ b/Michelf/MarkdownExtra.php
@@ -1295,10 +1295,10 @@ class MarkdownExtra extends \Michelf\Markdown {
 					(?:~{3,}|`{3,}) # 3 or more tildes/backticks.
 				)
 				[ ]*
-				(?: \.?([-_:a-zA-Z0-9]+) )? # 2: standalone class name
-				[ ]*
-				(?:	'.$this->id_class_attr_catch_re.' )? # 3: Extra attributes
-				
+				# #2: class name (optional) and #3: attributes (optional)
+				(?:
+					\.?([-_:a-zA-Z0-9]+)?[ ]*('.$this->id_class_attr_catch_re.')?
+				)?
 				[ ]* \n # Whitespace and newline following marker.
 				
 				# 4: Content
@@ -1319,7 +1319,7 @@ class MarkdownExtra extends \Michelf\Markdown {
 	protected function _doFencedCodeBlocks_callback($matches) {
 		$classname =& $matches[2];
 		$attrs     =& $matches[3];
-		$codeblock = $matches[4];
+		$codeblock = $matches[5];
 
 		if ($this->code_block_content_func) {
 			$codeblock = call_user_func($this->code_block_content_func, $codeblock, $classname);

--- a/Michelf/MarkdownExtra.php
+++ b/Michelf/MarkdownExtra.php
@@ -1292,11 +1292,10 @@ class MarkdownExtra extends \Michelf\Markdown {
 					(?:~{3,}|`{3,}) # 3 or more tildes/backticks.
 				)
 				[ ]*
-				(?:
-					\.?([-_:a-zA-Z0-9]+) # 2: standalone class name
-				|
-					'.$this->id_class_attr_catch_re.' # 3: Extra attributes
-				)?
+				(?: \.?([-_:a-zA-Z0-9]+) )? # 2: standalone class name
+				[ ]*
+				(?:	'.$this->id_class_attr_catch_re.' )? # 3: Extra attributes
+				
 				[ ]* \n # Whitespace and newline following marker.
 				
 				# 4: Content
@@ -1323,9 +1322,9 @@ class MarkdownExtra extends \Michelf\Markdown {
 			array($this, '_doFencedCodeBlocks_newlines'), $codeblock);
 
 		if ($classname != "") {
-			if ($classname{0} == '.')
-				$classname = substr($classname, 1);
-			$attr_str = ' class="'.$this->code_class_prefix.$classname.'"';
+			if ($classname{0} != '.')
+				$classname = ".$classname";
+			$attr_str = $this->doExtraAttributes($this->code_attr_on_pre ? "pre" : "code", "$classname $attrs");
 		} else {
 			$attr_str = $this->doExtraAttributes($this->code_attr_on_pre ? "pre" : "code", $attrs);
 		}

--- a/Michelf/MarkdownExtra.php
+++ b/Michelf/MarkdownExtra.php
@@ -1323,10 +1323,10 @@ class MarkdownExtra extends \Michelf\Markdown {
 
 		if ($this->code_block_content_func) {
 			$codeblock = call_user_func($this->code_block_content_func, $codeblock, $classname);
-			return "\n\n".$this->hashBlock($codeblock)."\n\n";
+		} else {
+			$codeblock = htmlspecialchars($codeblock, ENT_NOQUOTES);
 		}
 
-		$codeblock = htmlspecialchars($codeblock, ENT_NOQUOTES);
 		$codeblock = preg_replace_callback('/^\n+/',
 			array($this, '_doFencedCodeBlocks_newlines'), $codeblock);
 

--- a/Michelf/MarkdownExtra.php
+++ b/Michelf/MarkdownExtra.php
@@ -43,6 +43,9 @@ class MarkdownExtra extends \Michelf\Markdown {
 	# setting this to true will put attributes on the `pre` tag instead.
 	public $code_attr_on_pre = false;
 	
+	# Optional content function for code blocks
+	public $code_block_content_func = null;
+
 	# Predefined abbreviations.
 	public $predef_abbr = array();
 
@@ -1317,6 +1320,12 @@ class MarkdownExtra extends \Michelf\Markdown {
 		$classname =& $matches[2];
 		$attrs     =& $matches[3];
 		$codeblock = $matches[4];
+
+		if ($this->code_block_content_func) {
+			$codeblock = call_user_func($this->code_block_content_func, $codeblock, $classname);
+			return "\n\n".$this->hashBlock($codeblock)."\n\n";
+		}
+
 		$codeblock = htmlspecialchars($codeblock, ENT_NOQUOTES);
 		$codeblock = preg_replace_callback('/^\n+/',
 			array($this, '_doFencedCodeBlocks_newlines'), $codeblock);

--- a/Michelf/MarkdownExtra.php
+++ b/Michelf/MarkdownExtra.php
@@ -1295,9 +1295,12 @@ class MarkdownExtra extends \Michelf\Markdown {
 					(?:~{3,}|`{3,}) # 3 or more tildes/backticks.
 				)
 				[ ]*
-				# #2: class name (optional) and #3: attributes (optional)
 				(?:
-					\.?([-_:a-zA-Z0-9]+)?[ ]*('.$this->id_class_attr_catch_re.')?
+					\.?([-_:a-zA-Z0-9]+) # 2: standalone class name
+				)?
+				[ ]*
+				(?:
+					'.$this->id_class_attr_catch_re.' # 3: Extra attributes
 				)?
 				[ ]* \n # Whitespace and newline following marker.
 				
@@ -1319,7 +1322,7 @@ class MarkdownExtra extends \Michelf\Markdown {
 	protected function _doFencedCodeBlocks_callback($matches) {
 		$classname =& $matches[2];
 		$attrs     =& $matches[3];
-		$codeblock = $matches[5];
+		$codeblock = $matches[4];
 
 		if ($this->code_block_content_func) {
 			$codeblock = call_user_func($this->code_block_content_func, $codeblock, $classname);


### PR DESCRIPTION
This adds an optional code block content function to use customized renderers for code blocks (for example Geshi).
