### PR TITLE
Adding support for ~~strikethrough~~ in MarkdownExtra

### DIFF
--- a/Michelf/MarkdownExtra.php
+++ b/Michelf/MarkdownExtra.php
@@ -71,6 +71,7 @@ class MarkdownExtra extends \Michelf\Markdown {
 			);
 		$this->span_gamut += array(
 			"doFootnotes"        => 5,
+			"doStrikethrough"    => 55,
 			"doAbbreviations"    => 70,
 			);
 		
@@ -1616,4 +1617,32 @@ class MarkdownExtra extends \Michelf\Markdown {
 			return $matches[0];
 		}
 	}
+	
+	protected function doStrikethrough($text) {
+	#
+	# Strikethrough:
+	#    in:  text ~~deleted~~ from doc
+	#    out: text <del>deleted</del> from doc
+	#
+		$parts = preg_split('/(?<![~])(~~)(?![~])/', $text, null, PREG_SPLIT_DELIM_CAPTURE);
+		
+		//don't bother if nothing to do...
+		if(count($parts) <= 1)
+			return $text;
+		
+		$inTag = false;
+		foreach($parts as &$part) {
+			if($part == '~~') {
+				$part = ($inTag ? '</del>' : '<del>');
+				$inTag = !$inTag;
+			}
+		}
+		
+		//no hanging delimiter
+		if($inTag)
+			$parts[] = '</del>';
+		
+		return implode('', $parts);
+	}
+	
 }


### PR DESCRIPTION
This adds support for ~~strikethrough~~ syntax (`~~strikethrough~~`) in MarkdownExtra.

Related issue: https://github.com/michelf/php-markdown/issues/211
