### PR TITLE
Prevent iOS from mangling foot-note back-links

### DIFF
--- a/Michelf/MarkdownExtra.php
+++ b/Michelf/MarkdownExtra.php
@@ -32,6 +32,12 @@ class MarkdownExtra extends \Michelf\Markdown {
 	public $fn_link_class = "footnote-ref";
 	public $fn_backlink_class = "footnote-backref";
 
+	# Text to be displayed within footnote backlinks. The default is '↩'; the
+	# U+FE0E on the end is a Unicode variant selector used to prevent iOS from
+	# displaying the arrow character as an emoji. Note: This value is inserted
+	# as raw HTML, so dangerous/special characters must be pre-escaped!
+	public $fn_backlink_text = '&#8617;&#xFE0E;';
+
 	# Class name for table cell alignment (%% replaced left/center/right)
 	# For instance: 'go-%%' becomes 'go-left' or 'go-right' or 'go-center'
 	# If empty, the align attribute is used instead of a class name.
@@ -1475,6 +1481,7 @@ class MarkdownExtra extends \Michelf\Markdown {
 				$title = $this->encodeAttribute($title);
 				$attr .= " title=\"$title\"";
 			}
+			$backlink_text = $this->fn_backlink_text;
 			$num = 0;
 			
 			while (!empty($this->footnotes_ordered)) {
@@ -1494,9 +1501,9 @@ class MarkdownExtra extends \Michelf\Markdown {
 				$note_id = $this->encodeAttribute($note_id);
 
 				# Prepare backlink, multiple backlinks if multiple references
-				$backlink = "<a href=\"#fnref:$note_id\"$attr>&#8617;</a>";
+				$backlink = "<a href=\"#fnref:$note_id\"$attr>$backlink_text</a>";
 				for ($ref_num = 2; $ref_num <= $ref_count; ++$ref_num) {
-					$backlink .= " <a href=\"#fnref$ref_num:$note_id\"$attr>&#8617;</a>";
+					$backlink .= " <a href=\"#fnref$ref_num:$note_id\"$attr>$backlink_text</a>";
 				}
 				# Add backlink to last paragraph; create new paragraph if needed.
 				if (preg_match('{</p>$}', $footnote)) {


### PR DESCRIPTION
Safari (and probably other browsers) on iOS automatically converts the '↩' character used for foot-note back-links into [an emoji](https://www.emojibase.com/emoji/21a9/leftwardsarrowwithhook), which is inconsistent with desk-top browsers and (i think) just kind of dumb-looking. iOS can be [told to disable this behaviour](https://paulofierro.com/blog/2013/3/30/disabling-emoji-characters-with-unicode-variants) by appending a Unicode [variant selector](https://en.wikipedia.org/wiki/Variant_form_%28Unicode%29), `U+FE0E`, immediately following the would-be-emoji character. Unfortunately, it's not possible to do this with an `::after` selector in CSS, so the change must be made in the HTML itself. This PR makes that change.

I tested this in the following browsers and it worked as expected:
- Safari on iOS 9
- Firefox 43 on OS X 10.11
- Chrome 45 on OS X 10.11
- Safari 9 on OS X 10.11
- Chrome 44 on Ubuntu 14.04
