### PR TITLE
Allow overridable anchor text

### DIFF
--- a/Michelf/Markdown.php
+++ b/Michelf/Markdown.php
@@ -57,7 +57,7 @@ class Markdown implements MarkdownInterface {
 	
 	# Predefined urls and titles for reference links and images.
 	public $predef_urls = array();
-    public $predef_texts = array();
+	public $predef_texts = array();
 	public $predef_titles = array();
 
 	# Optional filter function for URLs
@@ -123,7 +123,7 @@ class Markdown implements MarkdownInterface {
 
 	# Internal hashes used during transformation.
 	protected $urls = array();
-    protected $texts = array();
+	protected $texts = array();
 	protected $titles = array();
 	protected $html_hashes = array();
 	
@@ -139,7 +139,7 @@ class Markdown implements MarkdownInterface {
 		# Clear global hashes.
 		$this->urls = $this->predef_urls;
 		$this->texts = $this->predef_texts;
-        $this->titles = $this->predef_titles;
+		$this->titles = $this->predef_titles;
 		$this->html_hashes = array();
 		
 		$this->in_anchor = false;
@@ -152,7 +152,7 @@ class Markdown implements MarkdownInterface {
 	#
 		$this->urls = array();
 		$this->texts = array();
-        $this->titles = array();
+		$this->titles = array();
 		$this->html_hashes = array();
 	}
 
@@ -626,11 +626,11 @@ class Markdown implements MarkdownInterface {
 				$title = $this->encodeAttribute($title);
 				$result .=  " title=\"$title\"";
 			}
-            if ( isset( $this->texts[$link_id] ) ) {
-                $link_text = $this->runSpanGamut($this->texts[$link_id]);
-            } else {
-                $link_text = $this->runSpanGamut($link_text);
-            }
+			if ( isset( $this->texts[$link_id] ) ) {
+				$link_text = $this->runSpanGamut($this->texts[$link_id]);
+			} else {
+				$link_text = $this->runSpanGamut($link_text);
+			}
 
 			$result .= ">$link_text</a>";
 			$result = $this->hashPart($result);
@@ -876,7 +876,7 @@ class Markdown implements MarkdownInterface {
 					  )
 					|
 					  (?=						# Lookahead for another kind of list
-					    \n
+						\n
 						\3						# Must have the same indentation
 						'.$other_marker_re.'[ ]+
 					  )

--- a/Michelf/Markdown.php
+++ b/Michelf/Markdown.php
@@ -57,6 +57,7 @@ class Markdown implements MarkdownInterface {
 	
 	# Predefined urls and titles for reference links and images.
 	public $predef_urls = array();
+    public $predef_texts = array();
 	public $predef_titles = array();
 
 	# Optional filter function for URLs
@@ -122,6 +123,7 @@ class Markdown implements MarkdownInterface {
 
 	# Internal hashes used during transformation.
 	protected $urls = array();
+    protected $texts = array();
 	protected $titles = array();
 	protected $html_hashes = array();
 	
@@ -136,7 +138,8 @@ class Markdown implements MarkdownInterface {
 	#
 		# Clear global hashes.
 		$this->urls = $this->predef_urls;
-		$this->titles = $this->predef_titles;
+		$this->texts = $this->predef_texts;
+        $this->titles = $this->predef_titles;
 		$this->html_hashes = array();
 		
 		$this->in_anchor = false;
@@ -148,7 +151,8 @@ class Markdown implements MarkdownInterface {
 	# which may be taking up memory unnecessarly.
 	#
 		$this->urls = array();
-		$this->titles = array();
+		$this->texts = array();
+        $this->titles = array();
 		$this->html_hashes = array();
 	}
 
@@ -622,8 +626,12 @@ class Markdown implements MarkdownInterface {
 				$title = $this->encodeAttribute($title);
 				$result .=  " title=\"$title\"";
 			}
-		
-			$link_text = $this->runSpanGamut($link_text);
+            if ( isset( $this->texts[$link_id] ) ) {
+                $link_text = $this->runSpanGamut($this->texts[$link_id]);
+            } else {
+                $link_text = $this->runSpanGamut($link_text);
+            }
+
 			$result .= ">$link_text</a>";
 			$result = $this->hashPart($result);
 		}

--- a/Michelf/MarkdownExtra.php
+++ b/Michelf/MarkdownExtra.php
@@ -801,12 +801,12 @@ class MarkdownExtra extends \Michelf\Markdown {
 			if (isset($this->ref_attr[$link_id]))
 				$result .= $this->ref_attr[$link_id];
 		
-            if ( isset( $this->texts[$link_id] ) ) {
-                $link_text = $this->runSpanGamut($this->texts[$link_id]);
-            } else {
-                $link_text = $this->runSpanGamut($link_text);
-            }
-            
+			if ( isset( $this->texts[$link_id] ) ) {
+				$link_text = $this->runSpanGamut($this->texts[$link_id]);
+			} else {
+				$link_text = $this->runSpanGamut($link_text);
+			}
+			
 			$link_text = $this->runSpanGamut($link_text);
 			$result .= ">$link_text</a>";
 			$result = $this->hashPart($result);

--- a/Michelf/MarkdownExtra.php
+++ b/Michelf/MarkdownExtra.php
@@ -801,6 +801,12 @@ class MarkdownExtra extends \Michelf\Markdown {
 			if (isset($this->ref_attr[$link_id]))
 				$result .= $this->ref_attr[$link_id];
 		
+            if ( isset( $this->texts[$link_id] ) ) {
+                $link_text = $this->runSpanGamut($this->texts[$link_id]);
+            } else {
+                $link_text = $this->runSpanGamut($link_text);
+            }
+            
 			$link_text = $this->runSpanGamut($link_text);
 			$result .= ">$link_text</a>";
 			$result = $this->hashPart($result);


### PR DESCRIPTION
Based on the existing use of `predef_urls` to set URLs for predefined blocks such as `ref` in the docs examples, in my project we came across a need to be able to dynamically set the URLs as well as titles when rendering a page.

This just adds the facility of being able to pass through a map in the same manner as `predef_urls` and `predef_titles` that will override the text that was set, meaning you can do things like

```
$content = "[page_14]";
$predef_urls = array('page_14' => '<dynamically generated page url>');
$predef_texts = array('page_14' => '<dynamically generated page title>');
```
