### PR TITLE
Add "p" and "li" elements to $auto_close_tags_re

### DIFF
--- a/Michelf/MarkdownExtra.php
+++ b/Michelf/MarkdownExtra.php
@@ -318,7 +318,7 @@ class MarkdownExtra extends \Michelf\Markdown {
 	 * Tags that do not need to be closed.
 	 * @var string
 	 */
-	protected $auto_close_tags_re = 'hr|img|param|source|track';
+	protected $auto_close_tags_re = 'hr|img|param|source|track|p|li';
 	
 	/**
 	 * Hashify HTML Blocks and "clean tags".


### PR DESCRIPTION
https://www.w3.org/TR/html5/syntax.html#optional-tags

I never close these in my own coding and wouldn't expect to need to do it now.
