### PR TITLE
Remove example file from autogenerated ZIP archives

### DIFF
--- a/.gitattributes
+++ b/.gitattributes
@@ -1,0 +1,1 @@
+/Readme.php export-ignore


### PR DESCRIPTION
This example file is not useful for production machines, so let's remove it from autogenerated ZIP archives.

Developers (the only ones that are interested in this) can still to a `git clone` (or simply take a look at the repo on GitHub :wink: ).
