### PR TITLE
composer: drop deprecated alias

### DIFF
--- a/composer.json
+++ b/composer.json
@@ -22,10 +22,5 @@
 	},
 	"autoload": {
  		"psr-0": { "Michelf": "" }
-	},
-	"extra": {
-		"branch-alias": {
-			"dev-lib": "1.4.x-dev"
-		}
 	}
 }


### PR DESCRIPTION
I recommend dropping alias, since it has not enough attention to keep them up to date. Usual case for cases most I've seen.
Now it's version 1.8-dev so it's been useless for a while now.
