### PR TITLE
Fix typo in phpdoc comment

### DIFF
--- a/Michelf/MarkdownExtra.php
+++ b/Michelf/MarkdownExtra.php
@@ -118,7 +118,7 @@ class MarkdownExtra extends \Michelf\Markdown {
 	protected $footnotes_ref_count = array();
 	protected $footnotes_numbers = array();
 	protected $abbr_desciptions = array();
-	/** @var @string */
+	/** @var string */
 	protected $abbr_word_re = '';
 	
 	/**


### PR DESCRIPTION
In the `MarkdownExtra` class one variable has been documented with `@var @string` instead of the correct `@var string`.

This leads to problems when used in combination with the [Doctrine Annotations library](https://github.com/doctrine/annotations) which will cause an error because `@string` is not a known annotation and not whitelisted as a phpdoc tag.