### PR TITLE
Refactor create_function into anonymous function

### DIFF
--- a/Michelf/Markdown.php
+++ b/Michelf/Markdown.php
@@ -1872,7 +1872,7 @@ class Markdown implements MarkdownInterface {
 
 		$this->utf8_strlen = function($text) {
 			return preg_match_all('/[\x00-\xBF]|[\xC0-\xFF][\x80-\xBF]*/', $text, $m);
-		}
+		};
 	}
 
 	/**

--- a/Michelf/Markdown.php
+++ b/Michelf/Markdown.php
@@ -1870,9 +1870,9 @@ class Markdown implements MarkdownInterface {
 			return;
 		}
 
-		$this->utf8_strlen = create_function('$text', 'return preg_match_all(
-			"/[\\\\x00-\\\\xBF]|[\\\\xC0-\\\\xFF][\\\\x80-\\\\xBF]*/", 
-			$text, $m);');
+		$this->utf8_strlen = function($text) {
+			return preg_match_all('/[\x00-\xBF]|[\xC0-\xFF][\x80-\xBF]*/', $text, $m);
+		}
 	}
 
 	/**


### PR DESCRIPTION
This is good for readability. The values in the regexp had to be escaped twice.

Anonymous functions is available since PHP 5.3, which is the minimum version for php-markdown anyway, so using this will not increase the version number dependency.
