### PR TITLE
Use PSR-4 for autoloading

### DIFF
--- a/Readme.md
+++ b/Readme.md
@@ -43,17 +43,28 @@ Before PHP 5.3.7, pcre.backtrack_limit defaults to 100 000, which is too small
 in many situations. You might need to set it to higher values. Later PHP
 releases defaults to 1 000 000, which is usually fine.
 
+Installation
+------------
+
+Install this library with composer:
+
+	$ composer require michelf/php-markdown
 
 Usage
 -----
 
-This library package is meant to be used with class autoloading. For autoloading
-to work, your project needs have setup a PSR-0-compatible autoloader. See the
-included Readme.php file for a minimal autoloader setup. (If you cannot use
-autoloading, see below.)
+This library package is meant to be used with
+composer's
+[autoloading](https://getcomposer.org/doc/01-basic-usage.md#autoloading). Simply
+include composer's generated `vendor/autoload.php`:
 
-With class autoloading in place, putting the 'Michelf' folder in your
-include path should be enough for this to work:
+	require 'vendor/autoload.php';
+
+Without composer, for autoloading to work, your project needs a
+PSR-4-compatible autoloader. See the included Readme.php file for a minimal
+autoloader setup. (If you cannot use autoloading, see below.)
+
+With class autoloading in place:
 
 	use Michelf\Markdown;
 	$my_html = Markdown::defaultTransform($my_text);

--- a/Readme.php
+++ b/Readme.php
@@ -4,9 +4,9 @@
 // through the Markdown filter. You can adapt this sample code in any way
 // you like.
 
-// Install PSR-0-compatible class autoloader
+// Install PSR-4-compatible class autoloader
 spl_autoload_register(function($class){
-	require preg_replace('{\\\\|_(?!.*\\\\)}', DIRECTORY_SEPARATOR, ltrim($class, '\\')).'.php';
+	require str_replace('\\', DIRECTORY_SEPARATOR, ltrim($class, '\\')).'.php';
 });
 
 // Get Markdown class

--- a/composer.json
+++ b/composer.json
@@ -21,6 +21,6 @@
 		"php": ">=5.3.0"
 	},
 	"autoload": {
- 		"psr-0": { "Michelf": "" }
+ 		"psr-4": { "Michelf\\": "Michelf/" }
 	}
 }


### PR DESCRIPTION
This change brings this library's autoloading up to modern standards in the larger PHP community and uses methods recommended by the PHP dependency manager, composer.

From PSR-0 http://www.php-fig.org/psr/psr-0/

> As of 2014-10-21 PSR-0 has been marked as deprecated. PSR-4 is now recommended as an alternative.

PSR-4: http://www.php-fig.org/psr/psr-4/

From composer https://getcomposer.org/doc/04-schema.md#autoload

> PSR-4 is the recommended way since it offers greater ease of use (no need to regenerate the autoloader when you add classes).