### PR TITLE
add dpub-aria roles for footnotes

### DIFF
--- a/Michelf/MarkdownExtra.php
+++ b/Michelf/MarkdownExtra.php
@@ -1610,7 +1610,7 @@ class MarkdownExtra extends \Michelf\Markdown {
 
 		if (!empty($this->footnotes_ordered)) {
 			$text .= "\n\n";
-			$text .= "<div class=\"footnotes\">\n";
+			$text .= "<div class=\"footnotes\" role=\"doc-endnotes\">\n";
 			$text .= "<hr" . $this->empty_element_suffix . "\n";
 			$text .= "<ol>\n\n";
 
@@ -1625,6 +1625,7 @@ class MarkdownExtra extends \Michelf\Markdown {
 				$title = $this->encodeAttribute($title);
 				$attr .= " title=\"$title\"";
 			}
+			$attr .= " role=\"doc-backlink\"";
 			$backlink_text = $this->fn_backlink_html;
 			$num = 0;
 
@@ -1656,7 +1657,7 @@ class MarkdownExtra extends \Michelf\Markdown {
 					$footnote .= "\n\n<p>$backlink</p>";
 				}
 
-				$text .= "<li id=\"fn:$note_id\">\n";
+				$text .= "<li id=\"fn:$note_id\" role=\"doc-endnote\">\n";
 				$text .= $footnote . "\n";
 				$text .= "</li>\n\n";
 			}
@@ -1701,6 +1702,7 @@ class MarkdownExtra extends \Michelf\Markdown {
 				$title = $this->encodeAttribute($title);
 				$attr .= " title=\"$title\"";
 			}
+			$attr .= " role=\"doc-reflink\"";
 
 			$attr = str_replace("%%", $num, $attr);
 			$node_id = $this->encodeAttribute($node_id);

--- a/Michelf/MarkdownExtra.php
+++ b/Michelf/MarkdownExtra.php
@@ -1624,6 +1624,7 @@ class MarkdownExtra extends \Michelf\Markdown {
 				$title = $this->fn_backlink_title;
 				$title = $this->encodeAttribute($title);
 				$attr .= " title=\"$title\"";
+				$attr .= " aria-label=\"$title\"";
 			}
 			$attr .= " role=\"doc-backlink\"";
 			$backlink_text = $this->fn_backlink_html;

--- a/Michelf/MarkdownExtra.php
+++ b/Michelf/MarkdownExtra.php
@@ -1702,7 +1702,7 @@ class MarkdownExtra extends \Michelf\Markdown {
 				$title = $this->encodeAttribute($title);
 				$attr .= " title=\"$title\"";
 			}
-			$attr .= " role=\"doc-reflink\"";
+			$attr .= " role=\"doc-noteref\"";
 
 			$attr = str_replace("%%", $num, $attr);
 			$node_id = $this->encodeAttribute($node_id);


### PR DESCRIPTION
The [Digital Publishing WAI-ARIA Module 1.0](https://www.w3.org/TR/dpub-aria/) has recently become a W3C recommendation. It contains semantic structures that are derived from EPUB.

I added the appropriate roles to footnotes. Note that I chose to use `doc-endnote` rather than `doc-footnote` because of this section of the spec:

> The doc-footnote role is only for representing individual notes that occur within the body of a work. For collections of notes that occur at the end of a section, see doc-endnotes.

Note that in order to be fully compliant the backlink needs an accessible name. The current name is `'&#8617;&#xFE0E;'` which is not very useful. We could duplicate the title as `aria-label`, but by default the title is currently empty.