### PR TITLE
Add a Travis CI Integration File

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -1,0 +1,30 @@
+language: php
+
+sudo: false
+
+cache:
+  directories:
+    - $HOME/.composer/
+
+# Run tests against all these PHP versions
+php:
+  - 5.4
+  - 5.5
+  - 5.6
+  - 7.0
+  - 7.1
+  - 7.2
+  - hhvm
+
+before_script:
+  - composer install --prefer-dist
+
+script:
+  - vendor/bin/phpunit --coverage-clover=coverage.clover
+
+# Uncomment out to submit code coverage report to scrutinizer
+#after_script:
+#  - wget https://scrutinizer-ci.com/ocular.phar; php ocular.phar code-coverage:upload --format=php-clover coverage.clover
+
+notifications:
+  email: false


### PR DESCRIPTION
# What

This adds a `.travis.yml` file that can be used with the free https://travis-ci.org/ system of continuous integration. I've set it to run the PHPUnit tests with PHP 5.4 through 7.2, and hhvm for good measure.

This way, when a PR is made, the tests will all run automatically and report back to Github if it failed for any reason. Note that to get Travis-CI integration turned on for this repo, the owner will have to go to the travis-ci website and sign in, and basically click a few buttons (it's super simple to add).