### PR TITLE
Activate Scrutinizer code coverage reports 

### DIFF
--- a/.scrutinizer.yml
+++ b/.scrutinizer.yml
@@ -14,7 +14,6 @@ build:
             coverage:
               file: 'clover.xml'
               format: 'clover'
-          #- php-scrutinizer-run
           -
             command: phpcs-run
             use_website_config: true

--- a/.scrutinizer.yml
+++ b/.scrutinizer.yml
@@ -1,7 +1,7 @@
 build:
   environment:
     php:
-      version: 7.0
+      version: '7.0.20'
   nodes:
     analysis:
       project_setup:

--- a/.scrutinizer.yml
+++ b/.scrutinizer.yml
@@ -1,0 +1,37 @@
+build:
+  environment:
+    php:
+      version: 7.0
+  nodes:
+    analysis:
+      project_setup:
+        override:
+          - 'true'
+      tests:
+        override:
+          -
+            command: 'vendor/bin/phpunit --coverage-clover=clover.xml'
+            coverage:
+              file: 'clover.xml'
+              format: 'clover'
+          #- php-scrutinizer-run
+          -
+            command: phpcs-run
+            use_website_config: true
+      environment:
+        node:
+          version: 6.0.0
+    tests: true
+filter:
+  excluded_paths:
+    - 'test/*'
+checks:
+  php: true
+coding_style:
+  php:
+    indentation:
+      general:
+        use_tabs: true
+    spaces:
+      around_operators:
+        concatenation: true

--- a/.travis.yml
+++ b/.travis.yml
@@ -20,7 +20,7 @@ before_script:
   - composer install --prefer-dist
 
 script:
-  - vendor/bin/phpunit --coverage-clover=coverage.clover
+  - vendor/bin/phpunit --log-junit=phpunit.log
 
 # Uncomment out to submit code coverage report to scrutinizer
 #after_script:


### PR DESCRIPTION
# What

Hello, this PR adds a `.scrutinizer.yml` file to the root level, which specifies some basic settings for the `scrutinizer-ci` system. While `travis-ci` is more geared towards running tests under various settings and environments, `scrutinizer-ci` is more of a code quality tool. The most important thing I think it adds though is the **code coverage** reporting, since Travis doesn't have a good interface for that.

With this enabled, you can easily see the code that isn't covered under unit test, and on PRs if they reduce, maintain, or increase code coverage. It will also tell you if any additional issues are introduced (though any of these checks can be customized or disabled if desired).

This PR also turns off code coverage generation in Travis, which will speed up those tests as it is not needed there.

This file was generated as a default set of rules which scrutinizer "guessed" as to the style of the project, for example tabs as indents, and spaces around operators. I imagine that anything it couldn't auto-detect it just ignores and won't report on it.

# Enabling

In order to enable this for the repository, you would have to go to scrutinizer-ci and sign in, then activate the repository just like with travis-ci. To get an idea of what this will look like when enabled, see the result of my fork of the project: https://scrutinizer-ci.com/g/michaelbutler/php-markdown/inspections/bc3dce83-9291-4210-aaf8-a820592238e4