### PR TITLE
Various little fixes

### DIFF
--- a/Michelf/Markdown.php
+++ b/Michelf/Markdown.php
@@ -85,25 +85,25 @@ class Markdown implements MarkdownInterface {
 
 	/**
 	 * Optional filter function for URLs
-	 * @var callable
+	 * @var callable|null
 	 */
 	public $url_filter_func = null;
 
 	/**
 	 * Optional header id="" generation callback function.
-	 * @var callable
+	 * @var callable|null
 	 */
 	public $header_id_func = null;
 
 	/**
 	 * Optional function for converting code block content to HTML
-	 * @var callable
+	 * @var callable|null
 	 */
 	public $code_block_content_func = null;
 
 	/**
 	 * Optional function for converting code span content to HTML.
-	 * @var callable
+	 * @var callable|null
 	 */
 	public $code_span_content_func = null;
 
@@ -1217,7 +1217,7 @@ class Markdown implements MarkdownInterface {
 		$codeblock = $matches[1];
 
 		$codeblock = $this->outdent($codeblock);
-		if ($this->code_block_content_func) {
+		if (is_callable($this->code_block_content_func)) {
 			$codeblock = call_user_func($this->code_block_content_func, $codeblock, "");
 		} else {
 			$codeblock = htmlspecialchars($codeblock, ENT_NOQUOTES);
@@ -1236,7 +1236,7 @@ class Markdown implements MarkdownInterface {
 	 * @return string
 	 */
 	protected function makeCodeSpan($code) {
-		if ($this->code_span_content_func) {
+		if (is_callable($this->code_span_content_func)) {
 			$code = call_user_func($this->code_span_content_func, $code);
 		} else {
 			$code = htmlspecialchars(trim($code), ENT_NOQUOTES);
@@ -1575,11 +1575,11 @@ class Markdown implements MarkdownInterface {
 	 * This function is *not* suitable for attributes enclosed in single quotes.
 	 *
 	 * @param  string $url
-	 * @param  string &$text Passed by reference
+	 * @param  string $text Passed by reference
 	 * @return string        URL
 	 */
 	protected function encodeURLAttribute($url, &$text = null) {
-		if ($this->url_filter_func) {
+		if (is_callable($this->url_filter_func)) {
 			$url = call_user_func($this->url_filter_func, $url);
 		}
 
@@ -1693,7 +1693,7 @@ class Markdown implements MarkdownInterface {
 	 * attribute special characters by Allan Odgaard.
 	 *
 	 * @param  string  $text
-	 * @param  string  &$tail
+	 * @param  string  $tail Passed by reference
 	 * @param  integer $head_length
 	 * @return string
 	 */
@@ -1791,7 +1791,7 @@ class Markdown implements MarkdownInterface {
 	 * Handle $token provided by parseSpan by determining its nature and
 	 * returning the corresponding value that should replace it.
 	 * @param  string $token
-	 * @param  string &$str
+	 * @param  string $str Passed by reference
 	 * @return string
 	 */
 	protected function handleSpanToken($token, &$str) {

--- a/Michelf/MarkdownExtra.php
+++ b/Michelf/MarkdownExtra.php
@@ -96,9 +96,9 @@ class MarkdownExtra extends \Michelf\Markdown {
 	 * `section` that will enclose the list of footnotes so they are
 	 * reachable to accessibility tools the same way they would be with the
 	 * default HTML output.
-	 * @var null|string
+	 * @var string
 	 */
-	public $footnotes_assembled = null;
+	public $footnotes_assembled = "";
 
 	/**
 	 * Parser implementation
@@ -154,6 +154,10 @@ class MarkdownExtra extends \Michelf\Markdown {
 	 */
 	protected $footnote_counter = 1;
 
+    /**
+     * Ref attribute for links
+     * @var array
+     */
 	protected $ref_attr = array();
 
 	/**
@@ -169,7 +173,7 @@ class MarkdownExtra extends \Michelf\Markdown {
 		$this->abbr_desciptions = array();
 		$this->abbr_word_re = '';
 		$this->footnote_counter = 1;
-		$this->footnotes_assembled = null;
+		$this->footnotes_assembled = "";
 
 		foreach ($this->predef_abbr as $abbr_word => $abbr_desc) {
 			if ($this->abbr_word_re)
@@ -191,7 +195,7 @@ class MarkdownExtra extends \Michelf\Markdown {
 		$this->abbr_word_re = '';
 
 		if ( ! $this->omit_footnotes )
-			$this->footnotes_assembled = null;
+			$this->footnotes_assembled = "";
 
 		parent::teardown();
 	}
@@ -733,8 +737,8 @@ class MarkdownExtra extends \Michelf\Markdown {
 					$tag = preg_replace($markdown_attr_re, '', $tag);
 
 					// Check if text inside this tag must be parsed in span mode.
-					$this->mode = $attr_m[2] . $attr_m[3];
-					$span_mode = $this->mode === 'span' || ($this->mode !== 'block' &&
+					$mode = $attr_m[2] . $attr_m[3];
+					$span_mode = $mode === 'span' || ($mode !== 'block' &&
 						preg_match('{^<(?:' . $this->contain_span_tags_re . ')\b}', $tag));
 
 					// Calculate indent before tag.

--- a/Michelf/MarkdownExtra.php
+++ b/Michelf/MarkdownExtra.php
@@ -96,9 +96,9 @@ class MarkdownExtra extends \Michelf\Markdown {
 	 * `section` that will enclose the list of footnotes so they are
 	 * reachable to accessibility tools the same way they would be with the
 	 * default HTML output.
-	 * @var string
+	 * @var null|string
 	 */
-	public $footnotes_assembled = "";
+	public $footnotes_assembled = null;
 
 	/**
 	 * Parser implementation
@@ -173,7 +173,7 @@ class MarkdownExtra extends \Michelf\Markdown {
 		$this->abbr_desciptions = array();
 		$this->abbr_word_re = '';
 		$this->footnote_counter = 1;
-		$this->footnotes_assembled = "";
+		$this->footnotes_assembled = null;
 
 		foreach ($this->predef_abbr as $abbr_word => $abbr_desc) {
 			if ($this->abbr_word_re)
@@ -195,7 +195,7 @@ class MarkdownExtra extends \Michelf\Markdown {
 		$this->abbr_word_re = '';
 
 		if ( ! $this->omit_footnotes )
-			$this->footnotes_assembled = "";
+			$this->footnotes_assembled = null;
 
 		parent::teardown();
 	}


### PR DESCRIPTION
* Check if property is callable with is_callable everywhere needed
* Remove the & from the docblock declaration of variable passed by
reference
* Make default value of $footnotes_assembled an empty string instead of
null because it is concatenated afterwards with a string
* Use $mode instead of $this->mode (undeclared property anyway, and not
used anywhere else afaik)
* Correct the docblock types for some variables


Hello,

I'm using php-markdown in my project ([elabftw](https://github.com/elabftw/elabftw/)) and I decided to try and contribute back to the projects on which I depend.

So here is my humble contribution, a few fixes here and there :)

Thanks for this great library!

Cheers,
~Nico