### PR TITLE
curly braces is deprecated in PHP 7.4

### DIFF
--- a/Michelf/Markdown.php
+++ b/Michelf/Markdown.php
@@ -951,7 +951,7 @@ class Markdown implements MarkdownInterface {
 			return $matches[0];
 		}
 
-		$level = $matches[2]{0} == '=' ? 1 : 2;
+		$level = $matches[2][0] == '=' ? 1 : 2;
 
 		// ID attribute generation
 		$idAtt = $this->_generateIdFromHeaderValue($matches[1]);
@@ -1357,7 +1357,7 @@ class Markdown implements MarkdownInterface {
 				} else {
 					// Other closing marker: close one em or strong and
 					// change current token state to match the other
-					$token_stack[0] = str_repeat($token{0}, 3-$token_len);
+					$token_stack[0] = str_repeat($token[0], 3-$token_len);
 					$tag = $token_len == 2 ? "strong" : "em";
 					$span = $text_stack[0];
 					$span = $this->runSpanGamut($span);
@@ -1382,7 +1382,7 @@ class Markdown implements MarkdownInterface {
 				} else {
 					// Reached opening three-char emphasis marker. Push on token
 					// stack; will be handled by the special condition above.
-					$em = $token{0};
+					$em = $token[0];
 					$strong = "$em$em";
 					array_unshift($token_stack, $token);
 					array_unshift($text_stack, '');
@@ -1795,9 +1795,9 @@ class Markdown implements MarkdownInterface {
 	 * @return string
 	 */
 	protected function handleSpanToken($token, &$str) {
-		switch ($token{0}) {
+		switch ($token[0]) {
 			case "\\":
-				return $this->hashPart("&#". ord($token{1}). ";");
+				return $this->hashPart("&#". ord($token[1]). ";");
 			case "`":
 				// Search for end marker in remaining text.
 				if (preg_match('/^(.*?[^`])'.preg_quote($token).'(?!`)(.*)$/sm',

--- a/Michelf/MarkdownExtra.php
+++ b/Michelf/MarkdownExtra.php
@@ -256,9 +256,9 @@ class MarkdownExtra extends \Michelf\Markdown {
 		$attributes = array();
 		$id = false;
 		foreach ($elements as $element) {
-			if ($element{0} === '.') {
+			if ($element[0] === '.') {
 				$classes[] = substr($element, 1);
-			} else if ($element{0} === '#') {
+			} else if ($element[0] === '#') {
 				if ($id === false) $id = substr($element, 1);
 			} else if (strpos($element, '=') > 0) {
 				$parts = explode('=', $element, 2);
@@ -553,14 +553,14 @@ class MarkdownExtra extends \Michelf\Markdown {
 				}
 			}
 			// Check for: Indented code block.
-			else if ($tag{0} === "\n" || $tag{0} === " ") {
+			else if ($tag[0] === "\n" || $tag[0] === " ") {
 				// Indented code block: pass it unchanged, will be handled
 				// later.
 				$parsed .= $tag;
 			}
 			// Check for: Code span marker
 			// Note: need to check this after backtick fenced code blocks
-			else if ($tag{0} === "`") {
+			else if ($tag[0] === "`") {
 				// Find corresponding end marker.
 				$tag_re = preg_quote($tag);
 				if (preg_match('{^(?>.+?|\n(?!\n))*?(?<!`)' . $tag_re . '(?!`)}',
@@ -594,7 +594,7 @@ class MarkdownExtra extends \Michelf\Markdown {
 			// Check for: Clean tag (like script, math)
 			//            HTML Comments, processing instructions.
 			else if (preg_match('{^<(?:' . $this->clean_tags_re . ')\b}', $tag) ||
-				$tag{1} === '!' || $tag{1} === '?')
+				$tag[1] === '!' || $tag[1] === '?')
 			{
 				// Need to parse tag and following text using the HTML parser.
 				// (don't check for markdown attribute)
@@ -609,7 +609,7 @@ class MarkdownExtra extends \Michelf\Markdown {
 				preg_match('{^</?(?:' . $enclosing_tag_re . ')\b}', $tag))
 			{
 				// Increase/decrease nested tag count.
-				if ($tag{1} === '/') {
+				if ($tag[1] === '/') {
 					$depth--;
 				} else if ($tag{strlen($tag)-2} !== '/') {
 					$depth++;
@@ -713,7 +713,7 @@ class MarkdownExtra extends \Michelf\Markdown {
 				// In that case, we return original text unchanged and pass the
 				// first character as filtered to prevent an infinite loop in the
 				// parent function.
-				return array($original_text{0}, substr($original_text, 1));
+				return array($original_text[0], substr($original_text, 1));
 			}
 
 			$block_text .= $parts[0]; // Text before current tag.
@@ -723,7 +723,7 @@ class MarkdownExtra extends \Michelf\Markdown {
 			// Check for: Auto-close tag (like <hr/>)
 			//			 Comments and Processing Instructions.
 			if (preg_match('{^</?(?:' . $this->auto_close_tags_re . ')\b}', $tag) ||
-				$tag{1} === '!' || $tag{1} === '?')
+				$tag[1] === '!' || $tag[1] === '?')
 			{
 				// Just add the tag to the block as if it was text.
 				$block_text .= $tag;
@@ -732,7 +732,7 @@ class MarkdownExtra extends \Michelf\Markdown {
 				// Increase/decrease nested tag count. Only do so if
 				// the tag's name match base tag's.
 				if (preg_match('{^</?' . $base_tag_name_re . '\b}', $tag)) {
-					if ($tag{1} === '/') {
+					if ($tag[1] === '/') {
 						$depth--;
 					} else if ($tag{strlen($tag)-2} !== '/') {
 						$depth++;
@@ -1125,7 +1125,7 @@ class MarkdownExtra extends \Michelf\Markdown {
 			return $matches[0];
 		}
 
-		$level = $matches[3]{0} === '=' ? 1 : 2;
+		$level = $matches[3][0] === '=' ? 1 : 2;
 
 		$defaultId = is_callable($this->header_id_func) ? call_user_func($this->header_id_func, $matches[1]) : null;
 
@@ -1519,7 +1519,7 @@ class MarkdownExtra extends \Michelf\Markdown {
 
 		$classes = array();
 		if ($classname !== "") {
-			if ($classname{0} === '.') {
+			if ($classname[0] === '.') {
 				$classname = substr($classname, 1);
 			}
 			$classes[] = $this->code_class_prefix . $classname;


### PR DESCRIPTION
`Deprecated:  Array and string offset access syntax with curly braces is deprecated in /usr/share/php/Michelf/Markdown.php on line xxx`

https://wiki.php.net/rfc/deprecate_curly_braces_array_access