### PR TITLE
Update travis-ci configuration to test in PHP7.3/4

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -7,6 +7,7 @@ cache:
     - $HOME/.composer/
 
 # Run tests against all these PHP versions
+# TODO: When it becomes possible in TravisCI, switch 7.4snapshot to plain 7.4
 php:
   - 5.4
   - 5.5
@@ -14,6 +15,8 @@ php:
   - 7.0
   - 7.1
   - 7.2
+  - 7.3
+  - 7.4snapshot
   - hhvm
 
 before_script:


### PR DESCRIPTION
Adds `7.3` and `7.4snapshot` to `.travis.yml`.

The `snapshot` part appears to be required at the moment, but I expect in a few days or weeks it will be able to switch to plain `7.4`.

I noticed that there is a deprecation notice for a bunch of the curly brace string accessors in the latest Release, please let me know if I can be of help to solve that. This library is used within [Sculpin](https://sculpin.io/), which I help maintain.