### PR TITLE
Treat <details> and <summary> as block level.

### DIFF
--- a/Michelf/Markdown.php
+++ b/Michelf/Markdown.php
@@ -354,7 +354,7 @@ class Markdown implements MarkdownInterface {
 		$block_tags_b_re = 'p|div|h[1-6]|blockquote|pre|table|dl|ol|ul|address|'.
 						   'script|noscript|style|form|fieldset|iframe|math|svg|'.
 						   'article|section|nav|aside|hgroup|header|footer|'.
-						   'figure';
+						   'figure|details|summary';
 
 		// Regular expression for the content of a block tag.
 		$nested_tags_level = 4;

--- a/Michelf/MarkdownExtra.php
+++ b/Michelf/MarkdownExtra.php
@@ -345,7 +345,7 @@ class MarkdownExtra extends \Michelf\Markdown {
 	 * Tags that are always treated as block tags
 	 * @var string
 	 */
-	protected $block_tags_re = 'p|div|h[1-6]|blockquote|pre|table|dl|ol|ul|address|form|fieldset|iframe|hr|legend|article|section|nav|aside|hgroup|header|footer|figcaption|figure';
+	protected $block_tags_re = 'p|div|h[1-6]|blockquote|pre|table|dl|ol|ul|address|form|fieldset|iframe|hr|legend|article|section|nav|aside|hgroup|header|footer|figcaption|figure|details|summary';
 
 	/**
 	 * Tags treated as block tags only if the opening tag is alone on its line

--- a/test/resources/php-markdown.mdtest/Inline HTML (Simple).html
+++ b/test/resources/php-markdown.mdtest/Inline HTML (Simple).html
@@ -14,6 +14,13 @@
 <hr class="foo"
     id="bar" >
 
+<p>Details and Summary:</p>
+
+<details>
+  <summary>Some details</summary>
+  <p>More info about the details.</p>
+</details>
+
 <p>Regression:</p>
 
 <pre>

--- a/test/resources/php-markdown.mdtest/Inline HTML (Simple).text
+++ b/test/resources/php-markdown.mdtest/Inline HTML (Simple).text
@@ -14,6 +14,13 @@ Hr's:
 <hr class="foo"
     id="bar" >
 
+Details and Summary:
+
+<details>
+  <summary>Some details</summary>
+  <p>More info about the details.</p>
+</details>
+
 Regression:
 
 <pre>


### PR DESCRIPTION
`<details>` and `<summary>` elements should never be wrapped in `<p></p>`.

Add test to `test\resources\php-markdown.mdtest\Inline HTML (Simple)` accordingly.