### PR TITLE
img: add width and height

### DIFF
--- a/Michelf/Markdown.php
+++ b/Michelf/Markdown.php
@@ -864,6 +864,10 @@ class Markdown implements MarkdownInterface {
 		if (isset($this->urls[$link_id])) {
 			$url = $this->encodeURLAttribute($this->urls[$link_id]);
 			$result = "<img src=\"$url\" alt=\"$alt_text\"";
+			list($width, $height, $type, $attr) = getimagesize($url);
+			if(isset($width)) $result .= " width=\"$width\"";
+			if(isset($height)) $result .= " height=\"$height\"";
+			if(isset($width) && isset($height)) $result .= " loading=\"lazy\"";
 			if (isset($this->titles[$link_id])) {
 				$title = $this->titles[$link_id];
 				$title = $this->encodeAttribute($title);
@@ -893,6 +897,10 @@ class Markdown implements MarkdownInterface {
 		$alt_text = $this->encodeAttribute($alt_text);
 		$url = $this->encodeURLAttribute($url);
 		$result = "<img src=\"$url\" alt=\"$alt_text\"";
+		list($width, $height, $type, $attr) = getimagesize($url);
+		if(isset($width)) $result .= " width=\"$width\"";
+		if(isset($height)) $result .= " height=\"$height\"";
+		if(isset($width) && isset($height)) $result .= " loading=\"lazy\"";
 		if (isset($title)) {
 			$title = $this->encodeAttribute($title);
 			$result .=  " title=\"$title\""; // $title already quoted

--- a/Michelf/Markdown.php
+++ b/Michelf/Markdown.php
@@ -864,10 +864,13 @@ class Markdown implements MarkdownInterface {
 		if (isset($this->urls[$link_id])) {
 			$url = $this->encodeURLAttribute($this->urls[$link_id]);
 			$result = "<img src=\"$url\" alt=\"$alt_text\"";
-			list($width, $height, $type, $attr) = getimagesize($url);
-			if(isset($width)) $result .= " width=\"$width\"";
-			if(isset($height)) $result .= " height=\"$height\"";
-			if(isset($width) && isset($height)) $result .= " loading=\"lazy\"";
+			if(file_exists($url))
+			{
+				list($width, $height, $type, $attr) = getimagesize($url);
+				if(isset($width)) $result .= " width=\"$width\"";
+				if(isset($height)) $result .= " height=\"$height\"";
+				if(isset($width) && isset($height)) $result .= " loading=\"lazy\"";
+			}
 			if (isset($this->titles[$link_id])) {
 				$title = $this->titles[$link_id];
 				$title = $this->encodeAttribute($title);
@@ -897,10 +900,13 @@ class Markdown implements MarkdownInterface {
 		$alt_text = $this->encodeAttribute($alt_text);
 		$url = $this->encodeURLAttribute($url);
 		$result = "<img src=\"$url\" alt=\"$alt_text\"";
-		list($width, $height, $type, $attr) = getimagesize($url);
-		if(isset($width)) $result .= " width=\"$width\"";
-		if(isset($height)) $result .= " height=\"$height\"";
-		if(isset($width) && isset($height)) $result .= " loading=\"lazy\"";
+		if(file_exists($url))
+		{
+			list($width, $height, $type, $attr) = getimagesize($url);
+			if(isset($width)) $result .= " width=\"$width\"";
+			if(isset($height)) $result .= " height=\"$height\"";
+			if(isset($width) && isset($height)) $result .= " loading=\"lazy\"";
+		}
 		if (isset($title)) {
 			$title = $this->encodeAttribute($title);
 			$result .=  " title=\"$title\""; // $title already quoted

--- a/Michelf/MarkdownExtra.php
+++ b/Michelf/MarkdownExtra.php
@@ -1030,10 +1030,13 @@ class MarkdownExtra extends \Michelf\Markdown {
 		if (isset($this->urls[$link_id])) {
 			$url = $this->encodeURLAttribute($this->urls[$link_id]);
 			$result = "<img src=\"$url\" alt=\"$alt_text\"";
-			list($width, $height, $type, $attr) = getimagesize($url);
-			if(isset($width)) $result .= " width=\"$width\"";
-			if(isset($height)) $result .= " height=\"$height\"";
-			if(isset($width) && isset($height)) $result .= " loading=\"lazy\"";
+			if(file_exists($url))
+			{
+				list($width, $height, $type, $attr) = getimagesize($url);
+				if(isset($width)) $result .= " width=\"$width\"";
+				if(isset($height)) $result .= " height=\"$height\"";
+				if(isset($width) && isset($height)) $result .= " loading=\"lazy\"";
+			}
 			if (isset($this->titles[$link_id])) {
 				$title = $this->titles[$link_id];
 				$title = $this->encodeAttribute($title);
@@ -1068,10 +1071,13 @@ class MarkdownExtra extends \Michelf\Markdown {
 		$alt_text = $this->encodeAttribute($alt_text);
 		$url = $this->encodeURLAttribute($url);
 		$result = "<img src=\"$url\" alt=\"$alt_text\"";
-		list($width, $height, $type, $attr) = getimagesize($url);
-		if(isset($width)) $result .= " width=\"$width\"";
-		if(isset($height)) $result .= " height=\"$height\"";
-		if(isset($width) && isset($height)) $result .= " loading=\"lazy\"";
+		if(file_exists($url))
+		{
+			list($width, $height, $type, $attr) = getimagesize($url);
+			if(isset($width)) $result .= " width=\"$width\"";
+			if(isset($height)) $result .= " height=\"$height\"";
+			if(isset($width) && isset($height)) $result .= " loading=\"lazy\"";
+		}
 		if (isset($title) && $title_quote) {
 			$title = $this->encodeAttribute($title);
 			$result .=  " title=\"$title\""; // $title already quoted

--- a/Michelf/MarkdownExtra.php
+++ b/Michelf/MarkdownExtra.php
@@ -1030,6 +1030,10 @@ class MarkdownExtra extends \Michelf\Markdown {
 		if (isset($this->urls[$link_id])) {
 			$url = $this->encodeURLAttribute($this->urls[$link_id]);
 			$result = "<img src=\"$url\" alt=\"$alt_text\"";
+			list($width, $height, $type, $attr) = getimagesize($url);
+			if(isset($width)) $result .= " width=\"$width\"";
+			if(isset($height)) $result .= " height=\"$height\"";
+			if(isset($width) && isset($height)) $result .= " loading=\"lazy\"";
 			if (isset($this->titles[$link_id])) {
 				$title = $this->titles[$link_id];
 				$title = $this->encodeAttribute($title);
@@ -1064,6 +1068,10 @@ class MarkdownExtra extends \Michelf\Markdown {
 		$alt_text = $this->encodeAttribute($alt_text);
 		$url = $this->encodeURLAttribute($url);
 		$result = "<img src=\"$url\" alt=\"$alt_text\"";
+		list($width, $height, $type, $attr) = getimagesize($url);
+		if(isset($width)) $result .= " width=\"$width\"";
+		if(isset($height)) $result .= " height=\"$height\"";
+		if(isset($width) && isset($height)) $result .= " loading=\"lazy\"";
 		if (isset($title) && $title_quote) {
 			$title = $this->encodeAttribute($title);
 			$result .=  " title=\"$title\""; // $title already quoted


### PR DESCRIPTION
This complies with HTML5 standards and let browser plan for the area to reserve to images before they load.
If provided, it allows us to enable native browser lazy loading for performance.