### PR TITLE
Exclude tests from release archives

### DIFF
--- a/.gitattributes
+++ b/.gitattributes
@@ -1,0 +1,1 @@
+/test export-ignore


### PR DESCRIPTION
In particular, this means that people using this package via composer do not download the test files, only the implementation.

If desired, I can also add other files not needed for production (readme, CI config etc).