### PR TITLE
Auto-generate preconfigured class attributes

### DIFF
--- a/Michelf/Markdown.php
+++ b/Michelf/Markdown.php
@@ -125,6 +125,8 @@ class Markdown implements MarkdownInterface {
 	 * @var bool
 	 */
 	public $enhanced_ordered_list = false;
+	
+	public $class_attributes = null;
 
 	/**
 	 * Parser implementation
@@ -752,6 +754,7 @@ class Markdown implements MarkdownInterface {
 				$result .=  " title=\"$title\"";
 			}
 
+			$result .= $this->build_class_attributes("a");
 			$link_text = $this->runSpanGamut($link_text);
 			$result .= ">$link_text</a>";
 			$result = $this->hashPart($result);
@@ -786,6 +789,7 @@ class Markdown implements MarkdownInterface {
 			$result .=  " title=\"$title\"";
 		}
 
+		$result .= $this->build_class_attributes("a");
 		$link_text = $this->runSpanGamut($link_text);
 		$result .= ">$link_text</a>";
 
@@ -869,6 +873,7 @@ class Markdown implements MarkdownInterface {
 				$title = $this->encodeAttribute($title);
 				$result .=  " title=\"$title\"";
 			}
+			$result .= $this->build_class_attributes("img");
 			$result .= $this->empty_element_suffix;
 			$result = $this->hashPart($result);
 		} else {
@@ -897,6 +902,7 @@ class Markdown implements MarkdownInterface {
 			$title = $this->encodeAttribute($title);
 			$result .=  " title=\"$title\""; // $title already quoted
 		}
+		$result .= $this->build_class_attributes("img");
 		$result .= $this->empty_element_suffix;
 
 		return $this->hashPart($result);
@@ -1905,5 +1911,26 @@ class Markdown implements MarkdownInterface {
 	 */
 	protected function _unhash_callback($matches) {
 		return $this->html_hashes[$matches[0]];
+	}
+
+	/**
+	 * Build html class attribute as preconfigured with the class_attributes field
+	 * 
+	 * @param $tag string
+	 * @return string
+	 */
+	protected function build_class_attributes($tag) {
+		if($this->class_attributes === null || !isset($this->class_attributes[$tag])) {
+			return "";
+		}
+		
+		$attributes = $this->class_attributes[$tag];
+		if(is_string($attributes)) {
+			return ' class="' . $attributes . '"';
+		} else if(is_array($attributes)) {
+			return ' class="' . implode(' ', $attributes) . '"';
+		} else {
+			return '';
+		}
 	}
 }


### PR DESCRIPTION
From my understanding it is currently impossible to let the Markdown library generate class attributes in the html output. While it would be possible to include those after the text has been generated via regex replace, it is much easier to configure the Markdown object beforehand, e.g. if you want all images in the output to have the "control-img" class.

I dont know if this is rather a thing I would only need for my specific use-case or if there is more interest in this, I created a pull-request for it.

In my use-case, I generate forum article html content from Markdown source files, inside of the general php generated html content. This exposes me to the following problem:

If I include images in the Markdown, there is currently no possibility to control their width and height, although there is a pull request open for this [exact issue](https://github.com/michelf/php-markdown/pull/351). I believe allowing class attributes to be added to generated html tags to use them in css styling purposes would make things quite a bit easier.

I currently did only include attribute generation for html tags `a` and `img`, however if accepted I can of course add support for the other tags generated as well.