### PR TITLE
Update minimum requirements and phpunit

### DIFF
--- a/composer.json
+++ b/composer.json
@@ -18,7 +18,7 @@
 		}
 	],
 	"require": {
-		"php": ">=7.2"
+		"php": ">=7.3"
 	},
 	"autoload": {
  		"psr-4": { "Michelf\\": "Michelf/" }

--- a/composer.json
+++ b/composer.json
@@ -18,12 +18,12 @@
 		}
 	],
 	"require": {
-		"php": ">=5.3.0"
+		"php": ">=7.4"
 	},
 	"autoload": {
  		"psr-4": { "Michelf\\": "Michelf/" }
 	},
 	"require-dev": {
-		"phpunit/phpunit": ">=4.3 <5.8"
+		"phpunit/phpunit": "^9.5"
 	}
 }

--- a/composer.json
+++ b/composer.json
@@ -18,7 +18,7 @@
 		}
 	],
 	"require": {
-		"php": ">=7.4"
+		"php": ">=7.2"
 	},
 	"autoload": {
  		"psr-4": { "Michelf\\": "Michelf/" }


### PR DESCRIPTION
PHP less than 7.2 is no longer supported (and 7.2 will be at EOL in a few weeks).  

Bumping to PHP 7 also allows a more current phpunit.