### PR TITLE
Cast attr to string to prevent a PHP deprecation warning in 8.1

### DIFF
--- a/Michelf/MarkdownExtra.php
+++ b/Michelf/MarkdownExtra.php
@@ -229,7 +229,7 @@ class MarkdownExtra extends \Michelf\Markdown {
 		}
 
 		// Split on components
-		preg_match_all('/[#.a-z][-_:a-zA-Z0-9=]+/', $attr, $matches);
+		preg_match_all('/[#.a-z][-_:a-zA-Z0-9=]+/', (string)$attr, $matches);
 		$elements = $matches[0];
 
 		// Handle classes and IDs (only first ID taken into account)

--- a/Michelf/MarkdownExtra.php
+++ b/Michelf/MarkdownExtra.php
@@ -229,7 +229,7 @@ class MarkdownExtra extends \Michelf\Markdown {
 		}
 
 		// Split on components
-		preg_match_all('/[#.a-z][-_:a-zA-Z0-9=]+/', (string)$attr, $matches);
+		preg_match_all('/[#.a-z][-_:a-zA-Z0-9=]+/', $attr ?? '', $matches);
 		$elements = $matches[0];
 
 		// Handle classes and IDs (only first ID taken into account)


### PR DESCRIPTION
I received this Deprecation notice when running unit tests for `sculpin` under PHP 8.1:

```
PHP Deprecated:  preg_match_all():
  Passing null to parameter #2 ($subject) of type string is deprecated
  in sculpin/vendor/michelf/php-markdown/Michelf/MarkdownExtra.php
  on line 252
```

I solved it in the leanest way possible, which was to cast `$attr` to `string`. Let me know if you would prefer a different solution.

And thanks for building this library! I've been quite happy with it.