### PR TITLE
Extend test fixture to accomodate #333

### DIFF
--- a/test/resources/markdown.mdtest/Amps and angle encoding.text
+++ b/test/resources/markdown.mdtest/Amps and angle encoding.text
@@ -16,6 +16,8 @@ Here's an inline [link](/script?foo=1&bar=2).
 
 Here's an inline [link](</script?foo=1&bar=2>).
 
+Gotta <8 tags that never end.
+Gotta <8 tags that never, ever end.
 
 [1]: http://example.com/?foo=1&bar=2
 [2]: http://att.com/  "AT&T"

--- a/test/resources/markdown.mdtest/Amps and angle encoding.xhtml
+++ b/test/resources/markdown.mdtest/Amps and angle encoding.xhtml
@@ -15,3 +15,5 @@
 <p>Here's an inline <a href="/script?foo=1&amp;bar=2">link</a>.</p>
 
 <p>Here's an inline <a href="/script?foo=1&amp;bar=2">link</a>.</p>
+
+<p>Gotta &lt;8 tags that never end. Gotta &lt;8 tags that never, ever end.</p>


### PR DESCRIPTION
It makes the tests fail if run with a relatively small recursion limit and no JIT:

```
php -dpcre.jit=0 -dpcre.recursion_limit=200 vendor/bin/phpunit
```

See #333