### PR TITLE
Exclude dev files from dist package

### DIFF
--- a/composer.json
+++ b/composer.json
@@ -39,6 +39,17 @@
 		],
 		"codestyle": "vendor/bin/php-cs-fixer fix Michelf --dry-run --verbose --show-progress=none",
 		"codestyle-fix": "vendor/bin/php-cs-fixer fix Michelf"
-	}
+	},
 
+	"archive": {
+		"exclude": [
+			"/.github/",
+			"/test/",
+			"/.editorconfig",
+			"/.gitignore",
+			"/.scrutinizer.yml",
+			"/.travis.yml",
+			"/phpunit.xml.dist"
+		]
+	}
 }


### PR DESCRIPTION
For the time being, when fetching the dist package from composer, all repository files are included.
Using `export-ignore` git attribute would permit to make the dist package ligther (see https://php.watch/articles/composer-gitattributes#export-ignore).

Ignore files weight: 195.5kB
Remaining files weight: 128.2kB