### PR TITLE
Remove type attributes

### DIFF
--- a/Michelf/Markdown.php
+++ b/Michelf/Markdown.php
@@ -18,7 +18,7 @@ class Markdown implements MarkdownInterface {
 	 * Define the package version
 	 * @var string
 	 */
-	const MARKDOWNLIB_VERSION = "2.0";
+	const MARKDOWNLIB_VERSION = "1.9.2";
 
 	/**
 	 * Simple function interface - Initialize the parser and return the result
@@ -49,34 +49,39 @@ class Markdown implements MarkdownInterface {
 	/**
 	 * Configuration variables
 	 */
+
 	/**
 	 * Change to ">" for HTML output.
+	 * @var string
 	 */
-	public string $empty_element_suffix = " />";
+	public $empty_element_suffix = " />";
 
 	/**
 	 * The width of indentation of the output markup
+	 * @var int
 	 */
-	public int $tab_width = 4;
+	public $tab_width = 4;
 
 	/**
 	 * Change to `true` to disallow markup or entities.
+	 * @var boolean
 	 */
-	public bool $no_markup   = false;
-	public bool $no_entities = false;
+	public $no_markup   = false;
+	public $no_entities = false;
 
 
 	/**
 	 * Change to `true` to enable line breaks on \n without two trailling spaces
 	 * @var boolean
 	 */
-	public bool $hard_wrap = false;
+	public $hard_wrap = false;
 
 	/**
 	 * Predefined URLs and titles for reference links and images.
+	 * @var array
 	 */
-	public array $predef_urls   = array();
-	public array $predef_titles = array();
+	public $predef_urls   = array();
+	public $predef_titles = array();
 
 	/**
 	 * Optional filter function for URLs
@@ -116,27 +121,32 @@ class Markdown implements MarkdownInterface {
 	 * <li>List item two</li>
 	 * <li>List item three</li>
 	 * </ol>
+	 *
+	 * @var bool
 	 */
-	public bool $enhanced_ordered_list = false;
+	public $enhanced_ordered_list = false;
 
 	/**
 	 * Parser implementation
 	 */
+
 	/**
 	 * Regex to match balanced [brackets].
 	 * Needed to insert a maximum bracked depth while converting to PHP.
+	 * @var int
 	 */
-	protected int $nested_brackets_depth = 6;
+	protected $nested_brackets_depth = 6;
 	protected $nested_brackets_re;
 
-	protected int $nested_url_parenthesis_depth = 4;
+	protected $nested_url_parenthesis_depth = 4;
 	protected $nested_url_parenthesis_re;
 
 	/**
 	 * Table of hash values for escaped characters:
+	 * @var string
 	 */
-	protected string $escape_chars = '\`*_{}[]()>#+-.!';
-	protected string $escape_chars_re;
+	protected $escape_chars = '\`*_{}[]()>#+-.!';
+	protected $escape_chars_re;
 
 	/**
 	 * Constructor function. Initialize appropriate member variables.
@@ -165,20 +175,23 @@ class Markdown implements MarkdownInterface {
 
 	/**
 	 * Internal hashes used during transformation.
+	 * @var array
 	 */
-	protected array $urls        = array();
+	protected $urls        = array();
 	protected $titles      = array();
-	protected array $html_hashes = array();
+	protected $html_hashes = array();
 
 	/**
 	 * Status flag to avoid invalid nesting.
+	 * @var boolean
 	 */
-	protected bool $in_anchor = false;
+	protected $in_anchor = false;
 
 	/**
 	 * Status flag to avoid invalid nesting.
+	 * @var boolean
 	 */
-	protected bool $in_emphasis_processing = false;
+	protected $in_emphasis_processing = false;
 
 	/**
 	 * Called before the transformation process starts to setup parser states.
@@ -250,8 +263,9 @@ class Markdown implements MarkdownInterface {
 
 	/**
 	 * Define the document gamut
+	 * @var array
 	 */
-	protected array $document_gamut = array(
+	protected $document_gamut = array(
 		// Strip link definitions, store in hashes.
 		"stripLinkDefinitions" => 20,
 		"runBasicBlockGamut"   => 30,
@@ -511,8 +525,9 @@ class Markdown implements MarkdownInterface {
 	/**
 	 * Define the block gamut - these are all the transformations that form
 	 * block-level tags like paragraphs, headers, and list items.
+	 * @var array
 	 */
-	protected array $block_gamut = array(
+	protected $block_gamut = array(
 		"doHeaders"         => 10,
 		"doHorizontalRules" => 20,
 		"doLists"           => 40,
@@ -582,8 +597,9 @@ class Markdown implements MarkdownInterface {
 	/**
 	 * These are all the transformations that occur *within* block-level
 	 * tags like paragraphs, headers, and list items.
+	 * @var array
 	 */
-	protected array $span_gamut = array(
+	protected $span_gamut = array(
 		// Process character escapes, code spans, and inline HTML
 		// in one shot.
 		"parseSpan"           => -30,
@@ -1089,8 +1105,9 @@ class Markdown implements MarkdownInterface {
 
 	/**
 	 * Nesting tracker for list levels
+	 * @var integer
 	 */
-	protected int $list_level = 0;
+	protected $list_level = 0;
 
 	/**
 	 * Process the contents of a single ordered or unordered list, splitting it
@@ -1231,7 +1248,7 @@ class Markdown implements MarkdownInterface {
 	 * Define the emphasis operators with their regex matches
 	 * @var array
 	 */
-	protected array $em_relist = array(
+	protected $em_relist = array(
 		''  => '(?:(?<!\*)\*(?!\*)|(?<!_)_(?!_))(?![\.,:;]?\s)',
 		'*' => '(?<![\s*])\*(?!\*)',
 		'_' => '(?<![\s_])_(?!_)',
@@ -1241,7 +1258,7 @@ class Markdown implements MarkdownInterface {
 	 * Define the strong operators with their regex matches
 	 * @var array
 	 */
-	protected array $strong_relist = array(
+	protected $strong_relist = array(
 		''   => '(?:(?<!\*)\*\*(?!\*)|(?<!_)__(?!_))(?![\.,:;]?\s)',
 		'**' => '(?<![\s*])\*\*(?!\*)',
 		'__' => '(?<![\s_])__(?!_)',
@@ -1251,7 +1268,7 @@ class Markdown implements MarkdownInterface {
 	 * Define the emphasis + strong operators with their regex matches
 	 * @var array
 	 */
-	protected array $em_strong_relist = array(
+	protected $em_strong_relist = array(
 		''    => '(?:(?<!\*)\*\*\*(?!\*)|(?<!_)___(?!_))(?![\.,:;]?\s)',
 		'***' => '(?<![\s*])\*\*\*(?!\*)',
 		'___' => '(?<![\s_])___(?!_)',
@@ -1259,8 +1276,9 @@ class Markdown implements MarkdownInterface {
 
 	/**
 	 * Container for prepared regular expressions
+	 * @var array|null
 	 */
-	protected ?array $em_strong_prepared_relist = null;
+	protected $em_strong_prepared_relist;
 
 	/**
 	 * Prepare regular expressions for searching emphasis tokens in any
@@ -1808,7 +1826,7 @@ class Markdown implements MarkdownInterface {
 	/**
 	 * String length function for detab. `_initDetab` will create a function to
 	 * handle UTF-8 if the default function does not exist.
-	 * can be a string or function
+	 * @var string|callable
 	 */
 	protected $utf8_strlen = 'mb_strlen';
 

--- a/Michelf/MarkdownExtra.php
+++ b/Michelf/MarkdownExtra.php
@@ -17,21 +17,25 @@ class MarkdownExtra extends \Michelf\Markdown {
 	/**
 	 * Configuration variables
 	 */
+
 	/**
 	 * Prefix for footnote ids.
+	 * @var string
 	 */
-	public string $fn_id_prefix = "";
+	public $fn_id_prefix = "";
 
 	/**
 	 * Optional title attribute for footnote links.
+	 * @var string
 	 */
-	public string $fn_link_title = "";
+	public $fn_link_title = "";
 
 	/**
 	 * Optional class attribute for footnote links and backlinks.
+	 * @var string
 	 */
-	public string $fn_link_class     = "footnote-ref";
-	public string $fn_backlink_class = "footnote-backref";
+	public $fn_link_class     = "footnote-ref";
+	public $fn_backlink_class = "footnote-backref";
 
 	/**
 	 * Content to be displayed within footnote backlinks. The default is '↩';
@@ -39,51 +43,59 @@ class MarkdownExtra extends \Michelf\Markdown {
 	 * from displaying the arrow character as an emoji.
 	 * Optionally use '^^' and '%%' to refer to the footnote number and
 	 * reference number respectively. {@see parseFootnotePlaceholders()}
+	 * @var string
 	 */
-	public string $fn_backlink_html = '&#8617;&#xFE0E;';
+	public $fn_backlink_html = '&#8617;&#xFE0E;';
 
 	/**
 	 * Optional title and aria-label attributes for footnote backlinks for
 	 * added accessibility (to ensure backlink uniqueness).
 	 * Use '^^' and '%%' to refer to the footnote number and reference number
 	 * respectively. {@see parseFootnotePlaceholders()}
+	 * @var string
 	 */
-	public string $fn_backlink_title = "";
-	public string $fn_backlink_label = "";
+	public $fn_backlink_title = "";
+	public $fn_backlink_label = "";
 
 	/**
 	 * Class name for table cell alignment (%% replaced left/center/right)
 	 * For instance: 'go-%%' becomes 'go-left' or 'go-right' or 'go-center'
 	 * If empty, the align attribute is used instead of a class name.
+	 * @var string
 	 */
-	public string $table_align_class_tmpl = '';
+	public $table_align_class_tmpl = '';
 
 	/**
 	 * Optional class prefix for fenced code block.
+	 * @var string
 	 */
-	public string $code_class_prefix = "";
+	public $code_class_prefix = "";
 
 	/**
 	 * Class attribute for code blocks goes on the `code` tag;
 	 * setting this to true will put attributes on the `pre` tag instead.
+	 * @var boolean
 	 */
-	public bool $code_attr_on_pre = false;
+	public $code_attr_on_pre = false;
 
 	/**
 	 * Predefined abbreviations.
+	 * @var array
 	 */
-	public array $predef_abbr = array();
+	public $predef_abbr = array();
 
 	/**
 	 * Only convert atx-style headers if there's a space between the header and #
+	 * @var boolean
 	 */
-	public bool $hashtag_protection = false;
+	public $hashtag_protection = false;
 
 	/**
 	 * Determines whether footnotes should be appended to the end of the document.
 	 * If true, footnote html can be retrieved from $this->footnotes_assembled.
+	 * @var boolean
 	 */
-	public bool $omit_footnotes = false;
+	public $omit_footnotes = false;
 
 
 	/**
@@ -95,8 +107,9 @@ class MarkdownExtra extends \Michelf\Markdown {
 	 * `section` that will enclose the list of footnotes so they are
 	 * reachable to accessibility tools the same way they would be with the
 	 * default HTML output.
+	 * @var null|string
 	 */
-	public ?string $footnotes_assembled = null;
+	public $footnotes_assembled = null;
 
 	/**
 	 * Parser implementation
@@ -136,23 +149,27 @@ class MarkdownExtra extends \Michelf\Markdown {
 
 	/**
 	 * Extra variables used during extra transformations.
+	 * @var array
 	 */
-	protected array $footnotes = array();
-	protected array $footnotes_ordered = array();
-	protected array $footnotes_ref_count = array();
-	protected array $footnotes_numbers = array();
-	protected array $abbr_desciptions = array();
-	protected string $abbr_word_re = '';
+	protected $footnotes = array();
+	protected $footnotes_ordered = array();
+	protected $footnotes_ref_count = array();
+	protected $footnotes_numbers = array();
+	protected $abbr_desciptions = array();
+	/** @var string */
+	protected $abbr_word_re = '';
 
 	/**
 	 * Give the current footnote number.
+	 * @var integer
 	 */
-	protected int $footnote_counter = 1;
+	protected $footnote_counter = 1;
 
     /**
-	 * Ref attribute for links
-	 */
-	protected array $ref_attr = array();
+     * Ref attribute for links
+     * @var array
+     */
+	protected $ref_attr = array();
 
 	/**
 	 * Setting up Extra-specific variables.
@@ -198,15 +215,18 @@ class MarkdownExtra extends \Michelf\Markdown {
 	/**
 	 * Extra attribute parser
 	 */
+
 	/**
 	 * Expression to use to catch attributes (includes the braces)
+	 * @var string
 	 */
-	protected string $id_class_attr_catch_re = '\{((?>[ ]*[#.a-z][-_:a-zA-Z0-9=]+){1,})[ ]*\}';
+	protected $id_class_attr_catch_re = '\{((?>[ ]*[#.a-z][-_:a-zA-Z0-9=]+){1,})[ ]*\}';
 
 	/**
 	 * Expression to use when parsing in a context when no capture is desired
+	 * @var string
 	 */
-	protected string $id_class_attr_nocatch_re = '\{(?>[ ]*[#.a-z][-_:a-zA-Z0-9=]+){1,}[ ]*\}';
+	protected $id_class_attr_nocatch_re = '\{(?>[ ]*[#.a-z][-_:a-zA-Z0-9=]+){1,}[ ]*\}';
 
 	/**
 	 * Parse attributes caught by the $this->id_class_attr_catch_re expression
@@ -320,31 +340,37 @@ class MarkdownExtra extends \Michelf\Markdown {
 	/**
 	 * HTML block parser
 	 */
+
 	/**
 	 * Tags that are always treated as block tags
+	 * @var string
 	 */
-	protected string $block_tags_re = 'p|div|h[1-6]|blockquote|pre|table|dl|ol|ul|address|form|fieldset|iframe|hr|legend|article|section|nav|aside|hgroup|header|footer|figcaption|figure|details|summary';
+	protected $block_tags_re = 'p|div|h[1-6]|blockquote|pre|table|dl|ol|ul|address|form|fieldset|iframe|hr|legend|article|section|nav|aside|hgroup|header|footer|figcaption|figure|details|summary';
 
 	/**
 	 * Tags treated as block tags only if the opening tag is alone on its line
+	 * @var string
 	 */
-	protected string $context_block_tags_re = 'script|noscript|style|ins|del|iframe|object|source|track|param|math|svg|canvas|audio|video';
+	protected $context_block_tags_re = 'script|noscript|style|ins|del|iframe|object|source|track|param|math|svg|canvas|audio|video';
 
 	/**
 	 * Tags where markdown="1" default to span mode:
+	 * @var string
 	 */
-	protected string $contain_span_tags_re = 'p|h[1-6]|li|dd|dt|td|th|legend|address';
+	protected $contain_span_tags_re = 'p|h[1-6]|li|dd|dt|td|th|legend|address';
 
 	/**
 	 * Tags which must not have their contents modified, no matter where
 	 * they appear
+	 * @var string
 	 */
-	protected string $clean_tags_re = 'script|style|math|svg';
+	protected $clean_tags_re = 'script|style|math|svg';
 
 	/**
 	 * Tags that do not need to be closed.
+	 * @var string
 	 */
-	protected string $auto_close_tags_re = 'hr|img|param|source|track';
+	protected $auto_close_tags_re = 'hr|img|param|source|track';
 
 	/**
 	 * Hashify HTML Blocks and "clean tags".
@@ -1525,17 +1551,17 @@ class MarkdownExtra extends \Michelf\Markdown {
 	 * work in the middle of a word.
 	 * @var array
 	 */
-	protected array $em_relist = array(
+	protected $em_relist = array(
 		''  => '(?:(?<!\*)\*(?!\*)|(?<![a-zA-Z0-9_])_(?!_))(?![\.,:;]?\s)',
 		'*' => '(?<![\s*])\*(?!\*)',
 		'_' => '(?<![\s_])_(?![a-zA-Z0-9_])',
 	);
-	protected array $strong_relist = array(
+	protected $strong_relist = array(
 		''   => '(?:(?<!\*)\*\*(?!\*)|(?<![a-zA-Z0-9_])__(?!_))(?![\.,:;]?\s)',
 		'**' => '(?<![\s*])\*\*(?!\*)',
 		'__' => '(?<![\s_])__(?![a-zA-Z0-9_])',
 	);
-	protected array $em_strong_relist = array(
+	protected $em_strong_relist = array(
 		''    => '(?:(?<!\*)\*\*\*(?!\*)|(?<![a-zA-Z0-9_])___(?!_))(?![\.,:;]?\s)',
 		'***' => '(?<![\s*])\*\*\*(?!\*)',
 		'___' => '(?<![\s_])___(?![a-zA-Z0-9_])',


### PR DESCRIPTION
As per https://github.com/michelf/php-markdown/pull/379#issuecomment-1254979771

To be clear, I would seriously _love_ to see a next major version with type annotations. But if there's a choice between getting a minor version bump and no release, I'd prefer to have the release pipeline going. If this makes any sense.

Please feel free to close this PR if you'd rather stick with typed properties.