### PR TITLE
v1.10.0

### DIFF
--- a/Michelf/Markdown.php
+++ b/Michelf/Markdown.php
@@ -4,7 +4,7 @@
  *
  * @package   php-markdown
  * @author    Michel Fortin <michel.fortin@michelf.com>
- * @copyright 2004-2019 Michel Fortin <https://michelf.com/projects/php-markdown/>
+ * @copyright 2004-2021 Michel Fortin <https://michelf.com/projects/php-markdown/>
  * @copyright (Original Markdown) 2004-2006 John Gruber <https://daringfireball.net/projects/markdown/>
  */
 
@@ -18,7 +18,7 @@ class Markdown implements MarkdownInterface {
 	 * Define the package version
 	 * @var string
 	 */
-	const MARKDOWNLIB_VERSION = "1.9.0";
+	const MARKDOWNLIB_VERSION = "1.9.1";
 
 	/**
 	 * Simple function interface - Initialize the parser and return the result

--- a/Michelf/MarkdownExtra.php
+++ b/Michelf/MarkdownExtra.php
@@ -4,7 +4,7 @@
  *
  * @package   php-markdown
  * @author    Michel Fortin <michel.fortin@michelf.com>
- * @copyright 2004-2019 Michel Fortin <https://michelf.com/projects/php-markdown/>
+ * @copyright 2004-2021 Michel Fortin <https://michelf.com/projects/php-markdown/>
  * @copyright (Original Markdown) 2004-2006 John Gruber <https://daringfireball.net/projects/markdown/>
  */
 

--- a/Readme.md
+++ b/Readme.md
@@ -1,7 +1,7 @@
 PHP Markdown
 ============
 
-PHP Markdown Lib 1.9.0 - 1 Dec 2019
+PHP Markdown Lib 1.9.1 - 23 Nov 2021
 
 by Michel Fortin  
 <https://michelf.ca/>
@@ -182,6 +182,17 @@ PHP Markdown, please visit [michelf.ca/donate].
 
 Version History
 ---------------
+
+PHP Markdown Lib 1.9.1 (23 Nov 2021)
+
+*	Now treating `<details>` and `<summary>` as block level so they don't
+	get wrapped in `<p>`.
+	(Thanks to Thomas Hochstein for the fix.)
+
+*	Fix for unintended blank title attribute when adding supplementary attributes
+	to a link in Markdown Extra.
+	(Thanks to Richie Black for the fix.)
+
 
 PHP Markdown Lib 1.9.0 (1 Dec 2019)
 
@@ -399,7 +410,7 @@ Copyright and License
 ---------------------
 
 PHP Markdown Lib
-Copyright (c) 2004-2019 Michel Fortin
+Copyright (c) 2004-2021 Michel Fortin
 <https://michelf.ca/>  
 All rights reserved.
 


### PR DESCRIPTION
Not entirely sure yet if this should be 2.0.0 or 1.10.0, but I'm leaning for 1.10.0 because it seems very unlikely type annotations would break any code and the new requirement for PHP 7.4 should be handled fine by composer.