### PR TITLE
Add id and class attr for table

### DIFF
--- a/Michelf/MarkdownExtra.php
+++ b/Michelf/MarkdownExtra.php
@@ -1154,6 +1154,7 @@ class MarkdownExtra extends \Michelf\Markdown {
 						[|] .* \n			# Row content.
 					)*
 				)
+				('.$this->id_class_attr_catch_re.')?	 # $4 = id/class attributes
 				(?=\n|\Z)					# Stop at final double newline.
 			}xm',
 			array($this, '_doTable_leadingPipe_callback'), $text);
@@ -1178,6 +1179,7 @@ class MarkdownExtra extends \Michelf\Markdown {
 						.* [|] .* \n		# Row content
 					)*
 				)
+				('.$this->id_class_attr_catch_re.')?	 # $4 = id/class attributes
 				(?=\n|\Z)					# Stop at final double newline.
 			}xm',
 			array($this, '_DoTable_callback'), $text);
@@ -1194,10 +1196,11 @@ class MarkdownExtra extends \Michelf\Markdown {
 		$head		= $matches[1];
 		$underline	= $matches[2];
 		$content	= $matches[3];
+		$id_class	= $matches[4];
 
 		$content	= preg_replace('/^ *[|]/m', '', $content);
 
-		return $this->_doTable_callback(array($matches[0], $head, $underline, $content));
+		return $this->_doTable_callback(array($matches[0], $head, $underline, $content, $id_class));
 	}
 
 	/**
@@ -1223,7 +1226,8 @@ class MarkdownExtra extends \Michelf\Markdown {
 		$head		= $matches[1];
 		$underline	= $matches[2];
 		$content	= $matches[3];
-		$attr       = [];
+		$id_class	= $matches[4];
+		$attr		= [];
 
 		// Remove any tailing pipes for each line.
 		$head		= preg_replace('/[|] *$/m', '', $head);
@@ -1251,7 +1255,8 @@ class MarkdownExtra extends \Michelf\Markdown {
 		$attr       = array_pad($attr, $col_count, '');
 
 		// Write column headers.
-		$text = "<table>\n";
+		$table_attr_str = $this->doExtraAttributes('table', $id_class, null, []);
+		$text = "<table {$table_attr_str}>\n"; 
 		$text .= "<thead>\n";
 		$text .= "<tr>\n";
 		foreach ($headers as $n => $header) {

--- a/Michelf/MarkdownExtra.php
+++ b/Michelf/MarkdownExtra.php
@@ -1196,7 +1196,7 @@ class MarkdownExtra extends \Michelf\Markdown {
 		$head		= $matches[1];
 		$underline	= $matches[2];
 		$content	= $matches[3];
-		$id_class	= $matches[4];
+		$id_class	= $matches[4] ?? null;
 
 		$content	= preg_replace('/^ *[|]/m', '', $content);
 
@@ -1226,7 +1226,7 @@ class MarkdownExtra extends \Michelf\Markdown {
 		$head		= $matches[1];
 		$underline	= $matches[2];
 		$content	= $matches[3];
-		$id_class	= $matches[4];
+		$id_class	= $matches[4] ?? null;
 		$attr		= [];
 
 		// Remove any tailing pipes for each line.
@@ -1256,7 +1256,7 @@ class MarkdownExtra extends \Michelf\Markdown {
 
 		// Write column headers.
 		$table_attr_str = $this->doExtraAttributes('table', $id_class, null, []);
-		$text = "<table {$table_attr_str}>\n"; 
+		$text = "<table$table_attr_str>\n"; 
 		$text .= "<thead>\n";
 		$text .= "<tr>\n";
 		foreach ($headers as $n => $header) {


### PR DESCRIPTION
Add id and class attr for table in Markdown:

```md
| ID | Name   | State |
| -: | :----- | :---: |
|  1 | Task A | DONE  |
|  2 | Task B | TODO  |
{ #id .class }
```

HTML:

```html
<table id="id" class="class">
   ...
</table>
```
