### PR TITLE
PHP 8.2 parse error Update Markdown.php

### DIFF
--- a/Michelf/Markdown.php
+++ b/Michelf/Markdown.php
@@ -52,7 +52,7 @@ class Markdown implements MarkdownInterface {
 	/**
 	 * Change to ">" for HTML output.
 	 */
-	public string $empty_element_suffix = " />";
+	public string $empty_element_suffix = ' />';
 
 	/**
 	 * The width of indentation of the output markup


### PR DESCRIPTION
ParseError: syntax error, unexpected 'string' (T_STRING), expecting function (T_FUNCTION) or const (T_CONST)