### PR TITLE
Check $parts variable for `false` value to prevent TypeError

### DIFF
--- a/Michelf/MarkdownExtra.php
+++ b/Michelf/MarkdownExtra.php
@@ -499,7 +499,7 @@ class MarkdownExtra extends \Michelf\Markdown {
 			$parsed .= $parts[0]; // Text before current tag.
 
 			// If end of $text has been reached. Stop loop.
-			if (count($parts) < 3) {
+			if ($parts === false || count($parts) < 3) {
 				$text = "";
 				break;
 			}


### PR DESCRIPTION
This currently throws a `TypeError` if `$parts` is `false`, which is a valid return value for `preg_split`.