### PR TITLE
Fix php deprecated notice improving handling of null parsed attr values

### DIFF
--- a/Michelf/MarkdownExtra.php
+++ b/Michelf/MarkdownExtra.php
@@ -224,7 +224,7 @@ class MarkdownExtra extends \Michelf\Markdown {
 	 * @return string
 	 */
 	protected function doExtraAttributes($tag_name, $attr, $defaultIdValue = null, $classes = array()) {
-		if (empty($attr) && !$defaultIdValue && empty($classes)) {
+		if (is_null($attr) || (empty($attr) && !$defaultIdValue && empty($classes))) {
 			return "";
 		}
 


### PR DESCRIPTION
Fix php deprecated notice improving handling of null parsed attr values